### PR TITLE
U/b remy/blocknvp tf1

### DIFF
--- a/gems/flows/bijector.py
+++ b/gems/flows/bijector.py
@@ -1,0 +1,1272 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Bijector base."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import collections
+import contextlib
+import re
+import weakref
+
+# Dependency imports
+import numpy as np
+import six
+import tensorflow as tf
+
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import tensorshape_util
+from tensorflow.python.util import deprecation  # pylint: disable=g-direct-tensorflow-import
+
+__all__ = [
+    "Bijector",
+    "ConditionalBijector",
+]
+
+
+def _get_current_graph():
+  if tf.executing_eagerly():
+    return None
+  return tf.compat.v1.get_default_graph()
+
+
+class _Mapping(
+    collections.namedtuple("_Mapping", ["x", "y", "ildj", "kwargs"])):
+  """Helper class to make it easier to manage caching in `Bijector`."""
+
+  def __new__(cls, x=None, y=None, ildj=None, kwargs=None):
+    """Custom __new__ so namedtuple items have defaults.
+    Args:
+      x: `Tensor` or None. Input to forward; output of inverse.
+      y: `Tensor` or None. Input to inverse; output of forward.
+      ildj: `Tensor`. This is the (un-reduce_sum'ed) inverse log det jacobian.
+      kwargs: Python dictionary. Extra args supplied to forward/inverse/etc
+        functions.
+    Returns:
+      mapping: New instance of _Mapping.
+    """
+    return super(_Mapping, cls).__new__(cls, x, y, ildj, kwargs)
+
+  @property
+  def subkey(self):
+    """Returns subkey used for caching (nested under either `x` or `y`)."""
+    return self._deep_tuple(self.kwargs)
+
+  def merge(self, x=None, y=None, ildj=None, kwargs=None, mapping=None):
+    """Returns new _Mapping with args merged with self.
+    Args:
+      x: `Tensor` or None. Input to forward; output of inverse.
+      y: `Tensor` or None. Input to inverse; output of forward.
+      ildj: `Tensor`. This is the (un-reduce_sum'ed) inverse log det jacobian.
+      kwargs: Python dictionary. Extra args supplied to forward/inverse/etc
+        functions.
+      mapping: Instance of _Mapping to merge. Can only be specified if no other
+        arg is specified.
+    Returns:
+      mapping: New instance of `_Mapping` which has inputs merged with self.
+    Raises:
+      ValueError: if mapping and any other arg is not `None`.
+    """
+    if mapping is None:
+      mapping = _Mapping(x=x, y=y, ildj=ildj, kwargs=kwargs)
+    elif any(arg is not None for arg in [x, y, ildj, kwargs]):
+      raise ValueError("Cannot simultaneously specify mapping and individual "
+                       "arguments.")
+
+    return _Mapping(
+        x=self._merge(self.x, mapping.x),
+        y=self._merge(self.y, mapping.y),
+        ildj=self._merge(self.ildj, mapping.ildj),
+        kwargs=self._merge(self.kwargs, mapping.kwargs, use_equals=True))
+
+  def remove(self, field):
+    """To support weak referencing, removes cache key from the cache value."""
+    return _Mapping(
+        x=None if field == "x" else self.x,
+        y=None if field == "y" else self.y,
+        ildj=self.ildj,
+        kwargs=self.kwargs)
+
+  def _merge(self, old, new, use_equals=False):
+    """Helper to merge which handles merging one value."""
+    if old is None:
+      return new
+    if new is None:
+      return old
+    if (old == new) if use_equals else (old is new):
+      return old
+    raise ValueError("Incompatible values: %s != %s" % (old, new))
+
+  def _deep_tuple(self, x):
+    """Converts nested `tuple`, `list`, or `dict` to nested `tuple`."""
+    if isinstance(x, dict):
+      return self._deep_tuple(tuple(sorted(x.items())))
+    elif isinstance(x, (list, tuple)):
+      return tuple(map(self._deep_tuple, x))
+
+    return x
+
+
+class WeakKeyDefaultDict(dict):
+  """`WeakKeyDictionary` which always adds `defaultdict(dict)` in getitem."""
+
+  # Q:Why not subclass `collections.defaultdict`?
+  # Subclassing collections.defaultdict means we have a more complicated `repr`,
+  # `str` which makes debugging the bijector cache more tedious. Additionally it
+  # means we need to think about passing through __init__ args but manually
+  # specifying the `default_factory`. That is, just overriding `__missing__`
+  # ends up being a lot cleaner.
+
+  # Q:Why not subclass `weakref.WeakKeyDictionary`?
+  # `weakref.WeakKeyDictionary` has an even worse `repr`, `str` than
+  # collections.defaultdict. Plus, since we want explicit control over how the
+  # keys are created we need to override __getitem__ which is the only feature
+  # of `weakref.WeakKeyDictionary` we're using.
+
+  # This is the "WeakKey" part.
+  def __getitem__(self, key):
+    weak_key = HashableWeakRef(key, lambda w: self.pop(w, None))
+    return super(WeakKeyDefaultDict, self).__getitem__(weak_key)
+
+  # This is the "DefaultDict" part.
+  def __missing__(self, key):
+    assert isinstance(key, HashableWeakRef)  # Can't happen.
+    return super(WeakKeyDefaultDict, self).setdefault(key, {})
+
+  # Everything that follows is only useful to help make debugging easier.
+
+  def __contains__(self, key):
+    return super(WeakKeyDefaultDict, self).__contains__(HashableWeakRef(key))
+
+  # We don't want mutation except through __getitem__.
+
+  def __setitem__(self, *args, **kwargs):
+    raise NotImplementedError()
+
+  def update(self, *args, **kwargs):
+    raise NotImplementedError()
+
+  def setdefault(self, *args, **kwargs):
+    raise NotImplementedError()
+
+
+class HashableWeakRef(weakref.ref):
+  """weakref.ref which makes np.array objects hashable."""
+
+  def __hash__(self):
+    x = self()
+    if not isinstance(x, np.ndarray):
+      return hash(x)
+    # Note: The following logic can never be reached by the public API because
+    # the bijector base class always calls `convert_to_tensor` before accessing
+    # the cache.
+    x.flags.writeable = False
+    return hash(str(x.__array_interface__) + str(id(x)))
+
+  def __repr__(self):
+    return repr(self())
+
+  def __str__(self):
+    return str(self())
+
+  def __eq__(self, other):
+    x = self()
+    if isinstance(x, np.ndarray):
+      y = other()
+      return (isinstance(y, np.ndarray) and
+              x.__array_interface__ == y.__array_interface__ and
+              id(x) == id(y))
+    return super(HashableWeakRef, self).__eq__(other)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Bijector(object):
+  r"""Interface for transformations of a `Distribution` sample.
+  Bijectors can be used to represent any differentiable and injective
+  (one to one) function defined on an open subset of `R^n`.  Some non-injective
+  transformations are also supported (see "Non Injective Transforms" below).
+  #### Mathematical Details
+  A `Bijector` implements a [smooth covering map](
+  https://en.wikipedia.org/wiki/Local_diffeomorphism), i.e., a local
+  diffeomorphism such that every point in the target has a neighborhood evenly
+  covered by a map ([see also](
+  https://en.wikipedia.org/wiki/Covering_space#Covering_of_a_manifold)).
+  A `Bijector` is used by `TransformedDistribution` but can be generally used
+  for transforming a `Distribution` generated `Tensor`. A `Bijector` is
+  characterized by three operations:
+  1. Forward
+     Useful for turning one random outcome into another random outcome from a
+     different distribution.
+  2. Inverse
+     Useful for "reversing" a transformation to compute one probability in
+     terms of another.
+  3. `log_det_jacobian(x)`
+     "The log of the absolute value of the determinant of the matrix of all
+     first-order partial derivatives of the inverse function."
+     Useful for inverting a transformation to compute one probability in terms
+     of another. Geometrically, the Jacobian determinant is the volume of the
+     transformation and is used to scale the probability.
+     We take the absolute value of the determinant before log to avoid NaN
+     values.  Geometrically, a negative determinant corresponds to an
+     orientation-reversing transformation.  It is ok for us to discard the sign
+     of the determinant because we only integrate everywhere-nonnegative
+     functions (probability densities) and the correct orientation is always the
+     one that produces a nonnegative integrand.
+  By convention, transformations of random variables are named in terms of the
+  forward transformation. The forward transformation creates samples, the
+  inverse is useful for computing probabilities.
+  #### Example Uses
+  - Basic properties:
+  ```python
+  x = ...  # A tensor.
+  # Evaluate forward transformation.
+  fwd_x = my_bijector.forward(x)
+  x == my_bijector.inverse(fwd_x)
+  x != my_bijector.forward(fwd_x)  # Not equal because x != g(g(x)).
+  ```
+  - Computing a log-likelihood:
+  ```python
+  def transformed_log_prob(bijector, log_prob, x):
+    return (bijector.inverse_log_det_jacobian(x, event_ndims=0) +
+            log_prob(bijector.inverse(x)))
+  ```
+  - Transforming a random outcome:
+  ```python
+  def transformed_sample(bijector, x):
+    return bijector.forward(x)
+  ```
+  #### Example Bijectors
+  - "Exponential"
+    ```none
+    Y = g(X) = exp(X)
+    X ~ Normal(0, 1)  # Univariate.
+    ```
+    Implies:
+    ```none
+      g^{-1}(Y) = log(Y)
+      |Jacobian(g^{-1})(y)| = 1 / y
+      Y ~ LogNormal(0, 1), i.e.,
+      prob(Y=y) = |Jacobian(g^{-1})(y)| * prob(X=g^{-1}(y))
+                = (1 / y) Normal(log(y); 0, 1)
+    ```
+    Here is an example of how one might implement the `Exp` bijector:
+    ```python
+      class Exp(Bijector):
+        def __init__(self, validate_args=False, name="exp"):
+          super(Exp, self).__init__(
+              validate_args=validate_args,
+              forward_min_event_ndims=0,
+              name=name)
+        def _forward(self, x):
+          return tf.exp(x)
+        def _inverse(self, y):
+          return tf.log(y)
+        def _inverse_log_det_jacobian(self, y):
+          return -self._forward_log_det_jacobian(self._inverse(y))
+        def _forward_log_det_jacobian(self, x):
+          # Notice that we needn't do any reducing, even when`event_ndims > 0`.
+          # The base Bijector class will handle reducing for us; it knows how
+          # to do so because we called `super` `__init__` with
+          # `forward_min_event_ndims = 0`.
+          return x
+      ```
+  - "Affine"
+    ```none
+    Y = g(X) = sqrtSigma * X + mu
+    X ~ MultivariateNormal(0, I_d)
+    ```
+    Implies:
+    ```none
+      g^{-1}(Y) = inv(sqrtSigma) * (Y - mu)
+      |Jacobian(g^{-1})(y)| = det(inv(sqrtSigma))
+      Y ~ MultivariateNormal(mu, sqrtSigma) , i.e.,
+      prob(Y=y) = |Jacobian(g^{-1})(y)| * prob(X=g^{-1}(y))
+                = det(sqrtSigma)^(-d) *
+                  MultivariateNormal(inv(sqrtSigma) * (y - mu); 0, I_d)
+      ```
+  #### Min_event_ndims and Naming
+  Bijectors are named for the dimensionality of data they act on (i.e. without
+  broadcasting). We can think of bijectors having an intrinsic `min_event_ndims`
+  , which is the minimum number of dimensions for the bijector act on. For
+  instance, a Cholesky decomposition requires a matrix, and hence
+  `min_event_ndims=2`.
+  Some examples:
+  `AffineScalar:  min_event_ndims=0`
+  `Affine:  min_event_ndims=1`
+  `Cholesky:  min_event_ndims=2`
+  `Exp:  min_event_ndims=0`
+  `Sigmoid:  min_event_ndims=0`
+  `SoftmaxCentered:  min_event_ndims=1`
+  Note the difference between `Affine` and `AffineScalar`. `AffineScalar`
+  operates on scalar events, whereas `Affine` operates on vector-valued events.
+  More generally, there is a `forward_min_event_ndims` and an
+  `inverse_min_event_ndims`. In most cases, these will be the same.
+  However, for some shape changing bijectors, these will be different
+  (e.g. a bijector which pads an extra dimension at the end, might have
+  `forward_min_event_ndims=0` and `inverse_min_event_ndims=1`.
+  #### Jacobian Determinant
+  The Jacobian determinant is a reduction over `event_ndims - min_event_ndims`
+  (`forward_min_event_ndims` for `forward_log_det_jacobian` and
+  `inverse_min_event_ndims` for `inverse_log_det_jacobian`).
+  To see this, consider the `Exp` `Bijector` applied to a `Tensor` which has
+  sample, batch, and event (S, B, E) shape semantics. Suppose the `Tensor`'s
+  partitioned-shape is `(S=[4], B=[2], E=[3, 3])`. The shape of the `Tensor`
+  returned by `forward` and `inverse` is unchanged, i.e., `[4, 2, 3, 3]`.
+  However the shape returned by `inverse_log_det_jacobian` is `[4, 2]` because
+  the Jacobian determinant is a reduction over the event dimensions.
+  Another example is the `Affine` `Bijector`. Because `min_event_ndims = 1`, the
+  Jacobian determinant reduction is over `event_ndims - 1`.
+  It is sometimes useful to implement the inverse Jacobian determinant as the
+  negative forward Jacobian determinant. For example,
+  ```python
+  def _inverse_log_det_jacobian(self, y):
+     return -self._forward_log_det_jac(self._inverse(y))  # Note negation.
+  ```
+  The correctness of this approach can be seen from the following claim.
+  - Claim:
+      Assume `Y = g(X)` is a bijection whose derivative exists and is nonzero
+      for its domain, i.e., `dY/dX = d/dX g(X) != 0`. Then:
+      ```none
+      (log o det o jacobian o g^{-1})(Y) = -(log o det o jacobian o g)(X)
+      ```
+  - Proof:
+      From the bijective, nonzero differentiability of `g`, the
+      [inverse function theorem](
+          https://en.wikipedia.org/wiki/Inverse_function_theorem)
+      implies `g^{-1}` is differentiable in the image of `g`.
+      Applying the chain rule to `y = g(x) = g(g^{-1}(y))` yields
+      `I = g'(g^{-1}(y))*g^{-1}'(y)`.
+      The same theorem also implies `g^{-1}'` is non-singular therefore:
+      `inv[ g'(g^{-1}(y)) ] = g^{-1}'(y)`.
+      The claim follows from [properties of determinant](
+  https://en.wikipedia.org/wiki/Determinant#Multiplicativity_and_matrix_groups).
+  Generally its preferable to directly implement the inverse Jacobian
+  determinant.  This should have superior numerical stability and will often
+  share subgraphs with the `_inverse` implementation.
+  #### Is_constant_jacobian
+  Certain bijectors will have constant jacobian matrices. For instance, the
+  `Affine` bijector encodes multiplication by a matrix plus a shift, with
+  jacobian matrix, the same aforementioned matrix.
+  `is_constant_jacobian` encodes the fact that the jacobian matrix is constant.
+  The semantics of this argument are the following:
+    * Repeated calls to "log_det_jacobian" functions with the same
+      `event_ndims` (but not necessarily same input), will return the first
+      computed jacobian (because the matrix is constant, and hence is input
+      independent).
+    * `log_det_jacobian` implementations are merely broadcastable to the true
+      `log_det_jacobian` (because, again, the jacobian matrix is input
+      independent). Specifically, `log_det_jacobian` is implemented as the
+      log jacobian determinant for a single input.
+      ```python
+      class Identity(Bijector):
+        def __init__(self, validate_args=False, name="identity"):
+          super(Identity, self).__init__(
+              is_constant_jacobian=True,
+              validate_args=validate_args,
+              forward_min_event_ndims=0,
+              name=name)
+        def _forward(self, x):
+          return x
+        def _inverse(self, y):
+          return y
+        def _inverse_log_det_jacobian(self, y):
+          return -self._forward_log_det_jacobian(self._inverse(y))
+        def _forward_log_det_jacobian(self, x):
+          # The full log jacobian determinant would be tf.zero_like(x).
+          # However, we circumvent materializing that, since the jacobian
+          # calculation is input independent, and we specify it for one input.
+          return tf.constant(0., x.dtype)
+      ```
+  #### Subclass Requirements
+  - Subclasses typically implement:
+      - `_forward`,
+      - `_inverse`,
+      - `_inverse_log_det_jacobian`,
+      - `_forward_log_det_jacobian` (optional).
+    The `_forward_log_det_jacobian` is called when the bijector is inverted via
+    the `Invert` bijector. If undefined, a slightly less efficiently
+    calculation, `-1 * _inverse_log_det_jacobian`, is used.
+    If the bijector changes the shape of the input, you must also implement:
+      - _forward_event_shape_tensor,
+      - _forward_event_shape (optional),
+      - _inverse_event_shape_tensor,
+      - _inverse_event_shape (optional).
+    By default the event-shape is assumed unchanged from input.
+  - If the `Bijector`'s use is limited to `TransformedDistribution` (or friends
+    like `QuantizedDistribution`) then depending on your use, you may not need
+    to implement all of `_forward` and `_inverse` functions.
+    Examples:
+      1. Sampling (e.g., `sample`) only requires `_forward`.
+      2. Probability functions (e.g., `prob`, `cdf`, `survival`) only require
+         `_inverse` (and related).
+      3. Only calling probability functions on the output of `sample` means
+        `_inverse` can be implemented as a cache lookup.
+    See "Example Uses" [above] which shows how these functions are used to
+    transform a distribution. (Note: `_forward` could theoretically be
+    implemented as a cache lookup but this would require controlling the
+    underlying sample generation mechanism.)
+  #### Non Injective Transforms
+  **WARNING** Handing of non-injective transforms is subject to change.
+  Non injective maps `g` are supported, provided their domain `D` can be
+  partitioned into `k` disjoint subsets, `Union{D1, ..., Dk}`, such that,
+  ignoring sets of measure zero, the restriction of `g` to each subset is a
+  differentiable bijection onto `g(D)`.  In particular, this imples that for
+  `y in g(D)`, the set inverse, i.e. `g^{-1}(y) = {x in D : g(x) = y}`, always
+  contains exactly `k` distinct points.
+  The property, `_is_injective` is set to `False` to indicate that the bijector
+  is not injective, yet satisfies the above condition.
+  The usual bijector API is modified in the case `_is_injective is False` (see
+  method docstrings for specifics).  Here we show by example the `AbsoluteValue`
+  bijector.  In this case, the domain `D = (-inf, inf)`, can be partitioned
+  into `D1 = (-inf, 0)`, `D2 = {0}`, and `D3 = (0, inf)`.  Let `gi` be the
+  restriction of `g` to `Di`, then both `g1` and `g3` are bijections onto
+  `(0, inf)`, with `g1^{-1}(y) = -y`, and `g3^{-1}(y) = y`.  We will use
+  `g1` and `g3` to define bijector methods over `D1` and `D3`.  `D2 = {0}` is
+  an oddball in that `g2` is one to one, and the derivative is not well defined.
+  Fortunately, when considering transformations of probability densities
+  (e.g. in `TransformedDistribution`), sets of measure zero have no effect in
+  theory, and only a small effect in 32 or 64 bit precision.  For that reason,
+  we define `inverse(0)` and `inverse_log_det_jacobian(0)` both as `[0, 0]`,
+  which is convenient and results in a left-semicontinuous pdf.
+  ```python
+  abs = tfp.bijectors.AbsoluteValue()
+  abs.forward(-1.)
+  ==> 1.
+  abs.forward(1.)
+  ==> 1.
+  abs.inverse(1.)
+  ==> (-1., 1.)
+  # The |dX/dY| is constant, == 1.  So Log|dX/dY| == 0.
+  abs.inverse_log_det_jacobian(1., event_ndims=0)
+  ==> (0., 0.)
+  # Special case handling of 0.
+  abs.inverse(0.)
+  ==> (0., 0.)
+  abs.inverse_log_det_jacobian(0., event_ndims=0)
+  ==> (0., 0.)
+  ```
+  """
+
+  @abc.abstractmethod
+  def __init__(self,
+               graph_parents=None,
+               is_constant_jacobian=False,
+               validate_args=False,
+               dtype=None,
+               forward_min_event_ndims=None,
+               inverse_min_event_ndims=None,
+               name=None):
+    """Constructs Bijector.
+    A `Bijector` transforms random variables into new random variables.
+    Examples:
+    ```python
+    # Create the Y = g(X) = X transform.
+    identity = Identity()
+    # Create the Y = g(X) = exp(X) transform.
+    exp = Exp()
+    ```
+    See `Bijector` subclass docstring for more details and specific examples.
+    Args:
+      graph_parents: Python list of graph prerequisites of this `Bijector`.
+      is_constant_jacobian: Python `bool` indicating that the Jacobian matrix is
+        not a function of the input.
+      validate_args: Python `bool`, default `False`. Whether to validate input
+        with asserts. If `validate_args` is `False`, and the inputs are invalid,
+        correct behavior is not guaranteed.
+      dtype: `tf.dtype` supported by this `Bijector`. `None` means dtype is not
+        enforced.
+      forward_min_event_ndims: Python `integer` indicating the minimum number of
+        dimensions `forward` operates on.
+      inverse_min_event_ndims: Python `integer` indicating the minimum number of
+        dimensions `inverse` operates on. Will be set to
+        `forward_min_event_ndims` by default, if no value is provided.
+      name: The name to give Ops created by the initializer.
+    Raises:
+      ValueError:  If neither `forward_min_event_ndims` and
+        `inverse_min_event_ndims` are specified, or if either of them is
+        negative.
+      ValueError:  If a member of `graph_parents` is not a `Tensor`.
+    """
+    self._graph_parents = graph_parents or []
+
+    if forward_min_event_ndims is None and inverse_min_event_ndims is None:
+      raise ValueError("Must specify at least one of `forward_min_event_ndims` "
+                       "and `inverse_min_event_ndims`.")
+    elif inverse_min_event_ndims is None:
+      inverse_min_event_ndims = forward_min_event_ndims
+    elif forward_min_event_ndims is None:
+      forward_min_event_ndims = inverse_min_event_ndims
+
+    if not isinstance(forward_min_event_ndims, int):
+      raise TypeError("Expected forward_min_event_ndims to be of "
+                      "type int, got {}".format(
+                          type(forward_min_event_ndims).__name__))
+
+    if not isinstance(inverse_min_event_ndims, int):
+      raise TypeError("Expected inverse_min_event_ndims to be of "
+                      "type int, got {}".format(
+                          type(inverse_min_event_ndims).__name__))
+
+    if forward_min_event_ndims < 0:
+      raise ValueError("forward_min_event_ndims must be a non-negative "
+                       "integer.")
+    if inverse_min_event_ndims < 0:
+      raise ValueError("inverse_min_event_ndims must be a non-negative "
+                       "integer.")
+
+    self._forward_min_event_ndims = forward_min_event_ndims
+    self._inverse_min_event_ndims = inverse_min_event_ndims
+    self._is_constant_jacobian = is_constant_jacobian
+    # Keyed by the current graph.
+    self._constant_ildj = {}
+    self._validate_args = validate_args
+    self._dtype = dtype
+    self._from_y = WeakKeyDefaultDict()
+    self._from_x = WeakKeyDefaultDict()
+    if name:
+      self._name = name
+    else:
+      # We want the default convention to be snake_case rather than CamelCase
+      # since `Chain` uses bijector.name as the kwargs dictionary key.
+      def camel_to_snake(name):
+        s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+        return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+      self._name = camel_to_snake(type(self).__name__.lstrip("_"))
+
+    for i, t in enumerate(self._graph_parents):
+      if t is None or not tf.is_tensor(t):
+        raise ValueError("Graph parent item %d is not a Tensor; %s." % (i, t))
+
+  @property
+  def graph_parents(self):
+    """Returns this `Bijector`'s graph_parents as a Python list."""
+    return self._graph_parents
+
+  @property
+  def forward_min_event_ndims(self):
+    """Returns the minimal number of dimensions bijector.forward operates on."""
+    return self._forward_min_event_ndims
+
+  @property
+  def inverse_min_event_ndims(self):
+    """Returns the minimal number of dimensions bijector.inverse operates on."""
+    return self._inverse_min_event_ndims
+
+  @property
+  def is_constant_jacobian(self):
+    """Returns true iff the Jacobian matrix is not a function of x.
+    Note: Jacobian matrix is either constant for both forward and inverse or
+    neither.
+    Returns:
+      is_constant_jacobian: Python `bool`.
+    """
+    return self._is_constant_jacobian
+
+  @property
+  def _is_injective(self):
+    """Returns true iff the forward map `g` is injective (one-to-one function).
+    **WARNING** This hidden property and its behavior are subject to change.
+    Note:  Non-injective maps `g` are supported, provided their domain `D` can
+    be partitioned into `k` disjoint subsets, `Union{D1, ..., Dk}`, such that,
+    ignoring sets of measure zero, the restriction of `g` to each subset is a
+    differentiable bijection onto `g(D)`.
+    Returns:
+      is_injective: Python `bool`.
+    """
+    return True
+
+  @property
+  def validate_args(self):
+    """Returns True if Tensor arguments will be validated."""
+    return self._validate_args
+
+  @property
+  def dtype(self):
+    """dtype of `Tensor`s transformable by this distribution."""
+    return self._dtype
+
+  @property
+  def name(self):
+    """Returns the string name of this `Bijector`."""
+    return self._name
+
+  def __call__(self, value, name=None, **kwargs):
+    """Applies or composes the `Bijector`, depending on input type.
+    This is a convenience function which applies the `Bijector` instance in
+    three different ways, depending on the input:
+    1. If the input is a `tfd.Distribution` instance, return
+       `tfd.TransformedDistribution(distribution=input, bijector=self)`.
+    2. If the input is a `tfb.Bijector` instance, return
+       `tfb.Chain([self, input])`.
+    3. Otherwise, return `self.forward(input)`
+    Args:
+      value: A `tfd.Distribution`, `tfb.Bijector`, or a `Tensor`.
+      name: Python `str` name given to ops created by this function.
+      **kwargs: Additional keyword arguments passed into the created
+        `tfd.TransformedDistribution`, `tfb.Bijector`, or `self.forward`.
+    Returns:
+      composition: A `tfd.TransformedDistribution` if the input was a
+        `tfd.Distribution`, a `tfb.Chain` if the input was a `tfb.Bijector`, or
+        a `Tensor` computed by `self.forward`.
+    #### Examples
+    ```python
+    sigmoid = tfb.Reciprocal()(
+        tfb.AffineScalar(shift=1.)(
+          tfb.Exp()(
+            tfb.AffineScalar(scale=-1.))))
+    # ==> `tfb.Chain([
+    #         tfb.Reciprocal(),
+    #         tfb.AffineScalar(shift=1.),
+    #         tfb.Exp(),
+    #         tfb.AffineScalar(scale=-1.),
+    #      ])`  # ie, `tfb.Sigmoid()`
+    log_normal = tfb.Exp()(tfd.Normal(0, 1))
+    # ==> `tfd.TransformedDistribution(tfd.Normal(0, 1), tfb.Exp())`
+    tfb.Exp()([-1., 0., 1.])
+    # ==> tf.exp([-1., 0., 1.])
+    ```
+    """
+
+    # To avoid circular dependencies and keep the implementation local to the
+    # `Bijector` class, we violate PEP8 guidelines and import here rather than
+    # at the top of the file.
+    from tensorflow_probability.python.bijectors import chain  # pylint: disable=g-import-not-at-top
+    from tensorflow_probability.python.distributions import distribution  # pylint: disable=g-import-not-at-top
+    from tensorflow_probability.python.distributions import transformed_distribution  # pylint: disable=g-import-not-at-top
+
+    # TODO(b/128841942): Handle Conditional distributions and bijectors.
+    if type(value) is transformed_distribution.TransformedDistribution:  # pylint: disable=unidiomatic-typecheck
+      # We cannot accept subclasses with different constructors here, because
+      # subclass constructors may accept constructor arguments TD doesn't know
+      # how to handle. e.g. `TypeError: __init__() got an unexpected keyword
+      # argument 'allow_nan_stats'` when doing
+      # `tfb.Identity()(tfd.Chi(df=1., allow_nan_stats=True))`.
+      new_kwargs = value.parameters
+      new_kwargs.update(kwargs)
+      new_kwargs["name"] = name or new_kwargs.get("name", None)
+      new_kwargs["bijector"] = self(value.bijector)
+      return transformed_distribution.TransformedDistribution(**new_kwargs)
+
+    if isinstance(value, distribution.Distribution):
+      return transformed_distribution.TransformedDistribution(
+          distribution=value,
+          bijector=self,
+          name=name,
+          **kwargs)
+
+    if isinstance(value, chain.Chain):
+      new_kwargs = kwargs.copy()
+      new_kwargs["bijectors"] = [self] + ([] if value.bijectors is None
+                                          else list(value.bijectors))
+      if "validate_args" not in new_kwargs:
+        new_kwargs["validate_args"] = value.validate_args
+      new_kwargs["name"] = name or value.name
+      return chain.Chain(**new_kwargs)
+
+    if isinstance(value, Bijector):
+      return chain.Chain([self, value], name=name, **kwargs)
+
+    return self._call_forward(value, name=name or "forward", **kwargs)
+
+  def _forward_event_shape_tensor(self, input_shape):
+    """Subclass implementation for `forward_event_shape_tensor` function."""
+    # By default, we assume event_shape is unchanged.
+    return input_shape
+
+  def forward_event_shape_tensor(self,
+                                 input_shape,
+                                 name="forward_event_shape_tensor"):
+    """Shape of a single sample from a single batch as an `int32` 1D `Tensor`.
+    Args:
+      input_shape: `Tensor`, `int32` vector indicating event-portion shape
+        passed into `forward` function.
+      name: name to give to the op
+    Returns:
+      forward_event_shape_tensor: `Tensor`, `int32` vector indicating
+        event-portion shape after applying `forward`.
+    """
+    with self._name_scope(name):
+      input_shape = tf.convert_to_tensor(
+          value=input_shape, dtype=tf.int32, name="input_shape")
+      return self._forward_event_shape_tensor(input_shape)
+
+  def _forward_event_shape(self, input_shape):
+    """Subclass implementation for `forward_event_shape` public function."""
+    # By default, we assume event_shape is unchanged.
+    return input_shape
+
+  def forward_event_shape(self, input_shape):
+    """Shape of a single sample from a single batch as a `TensorShape`.
+    Same meaning as `forward_event_shape_tensor`. May be only partially defined.
+    Args:
+      input_shape: `TensorShape` indicating event-portion shape passed into
+        `forward` function.
+    Returns:
+      forward_event_shape_tensor: `TensorShape` indicating event-portion shape
+        after applying `forward`. Possibly unknown.
+    """
+    return self._forward_event_shape(tf.TensorShape(input_shape))
+
+  def _inverse_event_shape_tensor(self, output_shape):
+    """Subclass implementation for `inverse_event_shape_tensor` function."""
+    # By default, we assume event_shape is unchanged.
+    return output_shape
+
+  def inverse_event_shape_tensor(self,
+                                 output_shape,
+                                 name="inverse_event_shape_tensor"):
+    """Shape of a single sample from a single batch as an `int32` 1D `Tensor`.
+    Args:
+      output_shape: `Tensor`, `int32` vector indicating event-portion shape
+        passed into `inverse` function.
+      name: name to give to the op
+    Returns:
+      inverse_event_shape_tensor: `Tensor`, `int32` vector indicating
+        event-portion shape after applying `inverse`.
+    """
+    with self._name_scope(name):
+      output_shape = tf.convert_to_tensor(
+          value=output_shape, dtype=tf.int32, name="output_shape")
+      return self._inverse_event_shape_tensor(output_shape)
+
+  def _inverse_event_shape(self, output_shape):
+    """Subclass implementation for `inverse_event_shape` public function."""
+    # By default, we assume event_shape is unchanged.
+    return tf.TensorShape(output_shape)
+
+  def inverse_event_shape(self, output_shape):
+    """Shape of a single sample from a single batch as a `TensorShape`.
+    Same meaning as `inverse_event_shape_tensor`. May be only partially defined.
+    Args:
+      output_shape: `TensorShape` indicating event-portion shape passed into
+        `inverse` function.
+    Returns:
+      inverse_event_shape_tensor: `TensorShape` indicating event-portion shape
+        after applying `inverse`. Possibly unknown.
+    """
+    return self._inverse_event_shape(tf.TensorShape(output_shape))
+
+  def _forward(self, x):
+    """Subclass implementation for `forward` public function."""
+    raise NotImplementedError("forward not implemented.")
+
+  def _call_forward(self, x, name, **kwargs):
+    """Wraps call to _forward, allowing extra shared logic."""
+    with self._name_scope(name):
+      x = tf.convert_to_tensor(value=x, name="x")
+      self._maybe_assert_dtype(x)
+      if not self._is_injective:  # No caching for non-injective
+        return self._forward(x, **kwargs)
+      mapping = self._lookup(x=x, kwargs=kwargs)
+      if mapping.y is not None:
+        return mapping.y
+      mapping = mapping.merge(y=self._forward(x, **kwargs))
+      # It's most important to cache the y->x mapping, because computing
+      # inverse(forward(y)) may be numerically unstable / lossy. Caching the
+      # x->y mapping only saves work. Since python doesn't support ephemerons,
+      # we cannot be simultaneously weak-keyed on both x and y, so we choose y.
+      self._cache_by_y(mapping)
+      if not tf.executing_eagerly():
+        self._cache_by_x(mapping)
+      return mapping.y
+
+  def forward(self, x, name="forward", **kwargs):
+    """Returns the forward `Bijector` evaluation, i.e., X = g(Y).
+    Args:
+      x: `Tensor`. The input to the "forward" evaluation.
+      name: The name to give this op.
+      **kwargs: Named arguments forwarded to subclass implementation.
+    Returns:
+      `Tensor`.
+    Raises:
+      TypeError: if `self.dtype` is specified and `x.dtype` is not
+        `self.dtype`.
+      NotImplementedError: if `_forward` is not implemented.
+    """
+    return self._call_forward(x, name, **kwargs)
+
+  def _inverse(self, y):
+    """Subclass implementation for `inverse` public function."""
+    raise NotImplementedError("inverse not implemented")
+
+  def _call_inverse(self, y, name, **kwargs):
+    """Wraps call to _inverse, allowing extra shared logic."""
+    with self._name_scope(name):
+      y = tf.convert_to_tensor(value=y, name="y")
+      self._maybe_assert_dtype(y)
+      if not self._is_injective:  # No caching for non-injective
+        return self._inverse(y, **kwargs)
+      mapping = self._lookup(y=y, kwargs=kwargs)
+      if mapping.x is not None:
+        return mapping.x
+      mapping = mapping.merge(x=self._inverse(y, **kwargs))
+      # It's most important to cache the x->y mapping, because computing
+      # forward(inverse(y)) may be numerically unstable / lossy. Caching the
+      # y->x mapping only saves work. Since python doesn't support ephemerons,
+      # we cannot be simultaneously weak-keyed on both x and y, so we choose x.
+      self._cache_by_x(mapping)
+      if not tf.executing_eagerly():
+        self._cache_by_y(mapping)
+      return mapping.x
+
+  def inverse(self, y, name="inverse", **kwargs):
+    """Returns the inverse `Bijector` evaluation, i.e., X = g^{-1}(Y).
+    Args:
+      y: `Tensor`. The input to the "inverse" evaluation.
+      name: The name to give this op.
+      **kwargs: Named arguments forwarded to subclass implementation.
+    Returns:
+      `Tensor`, if this bijector is injective.
+        If not injective, returns the k-tuple containing the unique
+        `k` points `(x1, ..., xk)` such that `g(xi) = y`.
+    Raises:
+      TypeError: if `self.dtype` is specified and `y.dtype` is not
+        `self.dtype`.
+      NotImplementedError: if `_inverse` is not implemented.
+    """
+    return self._call_inverse(y, name, **kwargs)
+
+  def _compute_inverse_log_det_jacobian_with_caching(
+      self, x, y, prefer_inverse_ldj_fn, event_ndims, kwargs):
+    """Compute ILDJ by the best available means, and ensure it is cached.
+    Sub-classes of Bijector may implement either `_forward_log_det_jacobian` or
+    `_inverse_log_det_jacobian`, or both, and may prefer one or the other for
+    reasons of computational efficiency and/or numerics. In general, to compute
+    the [I]LDJ, we need one of `x` or `y` and one of `_forward_log_det_jacobian`
+    or `_inverse_log_det_jacobian` (all bijectors implement `forward` and
+    `inverse`, so either of `x` and `y` may always computed from the other).
+    This method encapsulates the logic of selecting the best possible method of
+    computing the inverse log det jacobian, and executing it. Possible avenues
+    to obtaining this value are:
+      - recovering it from the cache,
+      - computing it as `-_forward_log_det_jacobian(x)`, where `x` may need to
+        be computed as `inverse(y)`, or
+      - computing it as `_inverse_log_det_jacobian(y)`, where `y` may need to
+        be computed as `forward(x)`.
+    To make things more interesting, we may be able to take advantage of the
+    knowledge that the jacobian is constant, for given `event_ndims`, and may
+    even cache that result.
+    To make things even more interesting still, we may need to perform an
+    additional `reduce_sum` over the event dims of an input after computing the
+    ILDJ (see `_reduce_jacobian_det_over_event` for the reduction logic). In
+    order to prevent spurious TF graph dependencies on past inputs in cached
+    results, we need to take care to do this reduction after the cache lookups.
+    This method takes care of all the above concerns.
+    Args:
+      x: a `Tensor`, the pre-Bijector transform value at whose post-Bijector
+        transform value the ILDJ is to be computed. Can be `None` as long as
+        `y` is not `None`.
+      y: a `Tensor`, a point in the output space of the Bijector's `forward`
+        transformation, at whose value the ILDJ is to be computed. Can be
+        `None` as long as `x` is not `None`.
+      prefer_inverse_ldj_fn: Python `bool`, if `True`, will strictly prefer to
+        use the `_inverse_log_det_jacobian` to compute ILDJ; else, will
+        strictly prefer to use `_forward_log_det_jacobian`.
+      event_ndims: int-like `Tensor`, the number of dims of an event (in the
+        pre- or post-transformed space, as appropriate). These need to be summed
+        over to compute the total ildj.
+      kwargs: dictionary of keyword args that will be passed to calls to
+        `self.forward` or `self.inverse` (if either of those are required), and
+        to `self._compute_unreduced_nonconstant_ildj_with_caching` or
+        `self._compute_unreduced_constant_ildj_with_caching`, as appropriate (
+        those functions use the conditioning kwargs for caching and for
+        their underlying computations).
+    Returns:
+      ildj: a Tensor of ILDJ['s] at the given input (as specified by the args).
+        Also updates the cache as needed.
+    """
+    # Ensure at least one of _inverse/_forward_log_det_jacobian is defined.
+    if not (hasattr(self, "_inverse_log_det_jacobian") or
+            hasattr(self, "_forward_log_det_jacobian")):
+      raise NotImplementedError(
+          "Neither _forward_log_det_jacobian nor _inverse_log_det_jacobian "
+          "is implemented. One or the other is required.")
+
+    # Use inverse_log_det_jacobian if either
+    #   1. it is preferred to *and* we are able, or
+    #   2. forward ldj fn isn't implemented (so we have no choice).
+    use_inverse_ldj_fn = (
+        (prefer_inverse_ldj_fn and hasattr(self, "_inverse_log_det_jacobian"))
+        or not hasattr(self, "_forward_log_det_jacobian"))
+
+    if use_inverse_ldj_fn:
+      tensor_to_use = y if y is not None else self.forward(x, **kwargs)
+      min_event_ndims = self.inverse_min_event_ndims
+    else:
+      tensor_to_use = x if x is not None else self.inverse(y, **kwargs)
+      min_event_ndims = self.forward_min_event_ndims
+
+    if self.is_constant_jacobian:
+      unreduced_ildj = self._compute_unreduced_constant_ildj_with_caching(
+          tensor_to_use, use_inverse_ldj_fn, kwargs)
+    else:
+      unreduced_ildj = self._compute_unreduced_nonconstant_ildj_with_caching(
+          x, y, tensor_to_use, use_inverse_ldj_fn, kwargs)
+
+    return self._reduce_jacobian_det_over_event(
+        tf.shape(input=tensor_to_use), unreduced_ildj, min_event_ndims,
+        event_ndims)
+
+  def _compute_unreduced_nonconstant_ildj_with_caching(
+      self, x, y, tensor_to_use, use_inverse_ldj_fn, kwargs):
+    """Helper for computing ILDJ, with caching, in the non-constant case.
+    Does not do the "reduce" step which is necessary in some cases; this is left
+    to the caller.
+    Args:
+      x: a `Tensor`, the pre-Bijector transform value at whose post-Bijector
+        transform value the ILDJ is to be computed. Can be `None` as long as
+        `y` is not `None`. This method only uses the value for cache
+        lookup/updating.
+      y: a `Tensor`, a point in the output space of the Bijector's `forward`
+        transformation, at whose value the ILDJ is to be computed. Can be
+        `None` as long as `x` is not `None`. This method only uses the value
+        for cache lookup/updating.
+      tensor_to_use: a `Tensor`, the one to actually pass to the chosen compute
+        function (`_inverse_log_det_jacobian` or `_forward_log_det_jacobian`).
+        It is presumed that the caller has already figured out what input to use
+        (it will either be the x or y value corresponding to the location where
+        we are computing the ILDJ).
+      use_inverse_ldj_fn: Python `bool`, if `True`, will use the
+        `_inverse_log_det_jacobian` to compute ILDJ; else, will use
+        `_forward_log_det_jacobian`.
+      kwargs: dictionary of keyword args that will be passed to calls to to
+        `_inverse_log_det_jacobian` or `_forward_log_det_jacobian`, as well as
+        for lookup/updating of the result in the cache.
+    Returns:
+      ildj: the (un-reduce_sum'ed) value of the ILDJ at the specified input
+      location. Also updates the cache as needed.
+    """
+    mapping = self._lookup(x=x, y=y, kwargs=kwargs)
+    if mapping.ildj is not None:
+      return mapping.ildj
+
+    if use_inverse_ldj_fn:
+      ildj = self._inverse_log_det_jacobian(tensor_to_use, **kwargs)
+    else:
+      ildj = -self._forward_log_det_jacobian(tensor_to_use, **kwargs)
+
+    mapping = mapping.merge(x=x, y=y, ildj=ildj)
+    self._cache_update(mapping)
+    return ildj
+
+  def _compute_unreduced_constant_ildj_with_caching(
+      self, tensor_to_use, use_inverse_ldj_fn, kwargs):
+    """Helper for computing ILDJ, with caching, in the constant-ILDJ case.
+    Does not do the "reduce" step which is necessary in some cases; this is left
+    to the caller.
+    Args:
+      tensor_to_use: a `Tensor`, to pass to the chosen compute
+        function (`_inverse_log_det_jacobian` or `_forward_log_det_jacobian`).
+        Since we know the ILDJ is input-independent, the actual value is not
+        meaningful, although the shape and dtype may be.
+      use_inverse_ldj_fn: Python `bool`, if `True`, will use the
+        `_inverse_log_det_jacobian` to compute ILDJ; else, will use
+        `_forward_log_det_jacobian`.
+      kwargs: dictionary of keyword args that will be passed to calls to
+        to `_inverse_log_det_jacobian` or `_forward_log_det_jacobian`, as well
+        as for lookup/updating of the result in the cache.
+    Returns:
+      ildj: the (un-reduce_sum'ed) value of the ILDJ for the specified input.
+        Also updates the cache as needed.
+    """
+    current_graph = _get_current_graph()
+    if current_graph in self._constant_ildj:
+      return self._constant_ildj[current_graph]
+
+    if use_inverse_ldj_fn:
+      ildj = self._inverse_log_det_jacobian(tensor_to_use, **kwargs)
+    else:
+      ildj = -self._forward_log_det_jacobian(tensor_to_use, **kwargs)
+    self._constant_ildj[current_graph] = ildj
+    return ildj
+
+  def _call_inverse_log_det_jacobian(self, y, event_ndims, name, **kwargs):
+    """Wraps call to _inverse_log_det_jacobian, allowing extra shared logic.
+    Specifically, this method
+      - adds a name scope,
+      - performs validations,
+      - handles the special case of non-injective Bijector (skip caching and
+        reduce_sum over the values at the multiple points in the preimage of `y`
+        under the non-injective transformation)
+    so that sub-classes don't have to worry about this stuff.
+    Args:
+      y: same as in `inverse_log_det_jacobian`
+      event_ndims: same as in `inverse_log_det_jacobian`
+      name: same as in `inverse_log_det_jacobian`
+      **kwargs: same as in `inverse_log_det_jacobian`
+    Returns:
+      ildj: the inverse log det jacobian at `y`. Also updates the cache as
+        needed.
+    """
+    with self._name_scope(name), tf.control_dependencies(
+        self._check_valid_event_ndims(
+            min_event_ndims=self.inverse_min_event_ndims,
+            event_ndims=event_ndims)):
+      y = tf.convert_to_tensor(value=y, name="y")
+      self._maybe_assert_dtype(y)
+
+      if not self._is_injective:
+        ildjs = self._inverse_log_det_jacobian(y, **kwargs)
+        return tuple(
+            self._reduce_jacobian_det_over_event(  # pylint: disable=g-complex-comprehension
+                tf.shape(input=y),
+                ildj,
+                self.inverse_min_event_ndims, event_ndims)
+            for ildj in ildjs)
+
+      return self._compute_inverse_log_det_jacobian_with_caching(
+          x=None,
+          y=y,
+          prefer_inverse_ldj_fn=True,
+          event_ndims=event_ndims,
+          kwargs=kwargs)
+
+  def inverse_log_det_jacobian(self,
+                               y,
+                               event_ndims,
+                               name="inverse_log_det_jacobian",
+                               **kwargs):
+    """Returns the (log o det o Jacobian o inverse)(y).
+    Mathematically, returns: `log(det(dX/dY))(Y)`. (Recall that: `X=g^{-1}(Y)`.)
+    Note that `forward_log_det_jacobian` is the negative of this function,
+    evaluated at `g^{-1}(y)`.
+    Args:
+      y: `Tensor`. The input to the "inverse" Jacobian determinant evaluation.
+      event_ndims: Number of dimensions in the probabilistic events being
+        transformed. Must be greater than or equal to
+        `self.inverse_min_event_ndims`. The result is summed over the final
+        dimensions to produce a scalar Jacobian determinant for each event, i.e.
+        it has shape `rank(y) - event_ndims` dimensions.
+      name: The name to give this op.
+      **kwargs: Named arguments forwarded to subclass implementation.
+    Returns:
+      ildj: `Tensor`, if this bijector is injective.
+        If not injective, returns the tuple of local log det
+        Jacobians, `log(det(Dg_i^{-1}(y)))`, where `g_i` is the restriction
+        of `g` to the `ith` partition `Di`.
+    Raises:
+      TypeError: if `self.dtype` is specified and `y.dtype` is not
+        `self.dtype`.
+      NotImplementedError: if `_inverse_log_det_jacobian` is not implemented.
+    """
+    return self._call_inverse_log_det_jacobian(y, event_ndims, name, **kwargs)
+
+  def _call_forward_log_det_jacobian(self, x, event_ndims, name, **kwargs):
+    """Wraps call to _forward_log_det_jacobian, allowing extra shared logic.
+    Specifically, this method
+      - adds a name scope,
+      - performs validations,
+      - handles the special case of non-injective Bijector (forward jacobian is
+        ill-defined in this case and we raise an exception)
+    so that sub-classes don't have to worry about this stuff.
+    Args:
+      x: same as in `forward_log_det_jacobian`
+      event_ndims: same as in `forward_log_det_jacobian`
+      name: same as in `forward_log_det_jacobian`
+      **kwargs: same as in `forward_log_det_jacobian`
+    Returns:
+      fldj: the forward log det jacobian at `x`. Also updates the cache as
+      needed.
+    """
+    if not self._is_injective:
+      raise NotImplementedError(
+          "forward_log_det_jacobian cannot be implemented for non-injective "
+          "transforms.")
+
+    with self._name_scope(name), tf.control_dependencies(
+        self._check_valid_event_ndims(
+            min_event_ndims=self.forward_min_event_ndims,
+            event_ndims=event_ndims)):
+      x = tf.convert_to_tensor(value=x, name="x")
+      self._maybe_assert_dtype(x)
+
+      return -self._compute_inverse_log_det_jacobian_with_caching(
+          x=x,
+          y=None,
+          prefer_inverse_ldj_fn=False,
+          event_ndims=event_ndims,
+          kwargs=kwargs)
+
+  def forward_log_det_jacobian(self,
+                               x,
+                               event_ndims,
+                               name="forward_log_det_jacobian",
+                               **kwargs):
+    """Returns both the forward_log_det_jacobian.
+    Args:
+      x: `Tensor`. The input to the "forward" Jacobian determinant evaluation.
+      event_ndims: Number of dimensions in the probabilistic events being
+        transformed. Must be greater than or equal to
+        `self.forward_min_event_ndims`. The result is summed over the final
+        dimensions to produce a scalar Jacobian determinant for each event, i.e.
+        it has shape `rank(x) - event_ndims` dimensions.
+      name: The name to give this op.
+      **kwargs: Named arguments forwarded to subclass implementation.
+    Returns:
+      `Tensor`, if this bijector is injective.
+        If not injective this is not implemented.
+    Raises:
+      TypeError: if `self.dtype` is specified and `y.dtype` is not
+        `self.dtype`.
+      NotImplementedError: if neither `_forward_log_det_jacobian`
+        nor {`_inverse`, `_inverse_log_det_jacobian`} are implemented, or
+        this is a non-injective bijector.
+    """
+    return self._call_forward_log_det_jacobian(x, event_ndims, name, **kwargs)
+
+  @contextlib.contextmanager
+  def _name_scope(self, name=None):
+    """Helper function to standardize op scope."""
+    with tf.compat.v2.name_scope(self.name):
+      with tf.compat.v2.name_scope(name) as scope:
+        yield scope
+
+  def _maybe_assert_dtype(self, x):
+    """Helper to check dtype when self.dtype is known."""
+    if (self.dtype is not None and
+        not dtype_util.base_equal(self.dtype, x.dtype)):
+      raise TypeError(
+          "Input had dtype %s but expected %s." % (x.dtype, self.dtype))
+
+  def _cache_by_x(self, mapping):
+    """Helper which stores new mapping info in the forward dict."""
+    # Merging from lookup is an added check that we're not overwriting anything
+    # which is not None.
+    mapping = mapping.merge(
+        mapping=self._lookup(mapping.x, mapping.y, mapping.kwargs))
+    if mapping.x is None:
+      raise ValueError("Caching expects x to be known, i.e., not None.")
+    self._from_x[mapping.x][mapping.subkey] = mapping.remove("x")
+
+  def _cache_by_y(self, mapping):
+    """Helper which stores new mapping info in the inverse dict."""
+    # Merging from lookup is an added check that we're not overwriting anything
+    # which is not None.
+    mapping = mapping.merge(
+        mapping=self._lookup(mapping.x, mapping.y, mapping.kwargs))
+    if mapping.y is None:
+      raise ValueError("Caching expects y to be known, i.e., not None.")
+    self._from_y[mapping.y][mapping.subkey] = mapping.remove("y")
+
+  def _cache_update(self, mapping):
+    """Helper which updates only those cached entries that already exist."""
+    if mapping.x is not None and mapping.subkey in self._from_x[mapping.x]:
+      self._cache_by_x(mapping)
+    if mapping.y is not None and mapping.subkey in self._from_y[mapping.y]:
+      self._cache_by_y(mapping)
+
+  def _lookup(self, x=None, y=None, kwargs=None):
+    """Helper which retrieves mapping info from forward/inverse dicts."""
+    mapping = _Mapping(x=x, y=y, kwargs=kwargs)
+    subkey = mapping.subkey
+    if x is not None:
+      # We removed x at caching time. Add it back if we lookup successfully.
+      mapping = self._from_x[x].get(subkey, mapping).merge(x=x)
+    if y is not None:
+      # We removed y at caching time. Add it back if we lookup successfully.
+      mapping = self._from_y[y].get(subkey, mapping).merge(y=y)
+    return mapping
+
+  def _reduce_jacobian_det_over_event(
+      self, shape_tensor, ildj, min_event_ndims, event_ndims):
+    """Reduce jacobian over event_ndims - min_event_ndims."""
+    # In this case, we need to tile the Jacobian over the event and reduce.
+    rank = tf.size(input=shape_tensor)
+    shape_tensor = shape_tensor[rank - event_ndims:rank - min_event_ndims]
+
+    ones = tf.ones(shape_tensor, ildj.dtype)
+    reduced_ildj = tf.reduce_sum(
+        input_tensor=ones * ildj,
+        axis=self._get_event_reduce_dims(min_event_ndims, event_ndims))
+
+    return reduced_ildj
+
+  def _get_event_reduce_dims(self, min_event_ndims, event_ndims):
+    """Compute the reduction dimensions given event_ndims."""
+    event_ndims_ = self._maybe_get_static_event_ndims(event_ndims)
+
+    if event_ndims_ is not None:
+      return [-index for index in range(1, event_ndims_ - min_event_ndims + 1)]
+    else:
+      reduce_ndims = event_ndims - min_event_ndims
+      return tf.range(-reduce_ndims, 0)
+
+  def _check_valid_event_ndims(self, min_event_ndims, event_ndims):
+    """Check whether event_ndims is atleast min_event_ndims."""
+    event_ndims = tf.convert_to_tensor(value=event_ndims, name="event_ndims")
+    event_ndims_ = tf.get_static_value(event_ndims)
+    assertions = []
+
+    if not dtype_util.is_integer(event_ndims.dtype):
+      raise ValueError("Expected integer dtype, got dtype {}".format(
+          event_ndims.dtype))
+
+    if event_ndims_ is not None:
+      if tensorshape_util.rank(event_ndims.shape) != 0:
+        raise ValueError("Expected scalar event_ndims, got shape {}".format(
+            event_ndims.shape))
+      if min_event_ndims > event_ndims_:
+        raise ValueError("event_ndims ({}) must be larger than "
+                         "min_event_ndims ({})".format(event_ndims_,
+                                                       min_event_ndims))
+    elif self.validate_args:
+      assertions += [
+          assert_util.assert_greater_equal(event_ndims, min_event_ndims)
+      ]
+
+    if tensorshape_util.is_fully_defined(event_ndims.shape):
+      if tensorshape_util.rank(event_ndims.shape) != 0:
+        raise ValueError("Expected scalar shape, got ndims {}".format(
+            tensorshape_util.rank(event_ndims.shape)))
+
+    elif self.validate_args:
+      assertions += [
+          assert_util.assert_rank(event_ndims, 0, message="Expected scalar.")
+      ]
+    return assertions
+
+  def _maybe_get_static_event_ndims(self, event_ndims):
+    """Helper which returns tries to return an integer static value."""
+    event_ndims_ = distribution_util.maybe_get_static_value(event_ndims)
+
+    if isinstance(event_ndims_, (np.generic, np.ndarray)):
+      if event_ndims_.dtype not in (np.int32, np.int64):
+        raise ValueError("Expected integer dtype, got dtype {}".format(
+            event_ndims_.dtype))
+
+      if isinstance(event_ndims_, np.ndarray) and len(event_ndims_.shape):
+        raise ValueError(
+            "Expected a scalar integer, got {}".format(event_ndims_))
+      event_ndims_ = int(event_ndims_)
+
+    return event_ndims_
+
+
+class ConditionalBijector(Bijector):
+  """Conditional Bijector is a Bijector that allows intrinsic conditioning."""
+
+  @deprecation.deprecated(
+      "2019-07-01",
+      "`ConditionalBijector` is no longer required; `Bijector` "
+      "top-level functions now pass-through `**kwargs`.",
+      warn_once=True)
+  def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
+    return super(ConditionalBijector, cls).__new__(cls)

--- a/gems/flows/chain.py
+++ b/gems/flows/chain.py
@@ -1,0 +1,318 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Chain bijector."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import itertools
+
+import tensorflow.compat.v2 as tf
+# from tensorflow_probability.python.bijectors import bijector
+from gems.flows import bijector
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import tensorshape_util
+
+
+__all__ = [
+    "Chain",
+]
+
+
+def _use_static_shape(input_tensor, ndims):
+  return (tensorshape_util.is_fully_defined(input_tensor.shape) and
+          isinstance(ndims, int))
+
+
+def _compute_min_event_ndims(bijector_list, compute_forward=True):
+  """Computes the min_event_ndims associated with the give list of bijectors.
+
+  Given a list `bijector_list` of bijectors, compute the min_event_ndims that is
+  associated with the composition of bijectors in that list.
+
+  min_event_ndims is the # of right most dimensions for which the bijector has
+  done necessary computation on (i.e. the non-broadcastable part of the
+  computation).
+
+  We can derive the min_event_ndims for a chain of bijectors as follows:
+
+  In the case where there are no rank changing bijectors, this will simply be
+  `max(b.forward_min_event_ndims for b in bijector_list)`. This is because the
+  bijector with the most forward_min_event_ndims requires the most dimensions,
+  and hence the chain also requires operating on those dimensions.
+
+  However in the case of rank changing, more care is needed in determining the
+  exact amount of dimensions. Padding dimensions causes subsequent bijectors to
+  operate on the padded dimensions, and Removing dimensions causes bijectors to
+  operate more left.
+
+  Args:
+    bijector_list: List of bijectors to be composed by chain.
+    compute_forward: Boolean. If True, computes the min_event_ndims associated
+      with a forward call to Chain, and otherwise computes the min_event_ndims
+      associated with an inverse call to Chain. The latter is the same as the
+      min_event_ndims associated with a forward call to Invert(Chain(....)).
+
+  Returns:
+    min_event_ndims
+  """
+  min_event_ndims = 0
+  # This is a mouthful, but what this encapsulates is that if not for rank
+  # changing bijectors, we'd only need to compute the largest of the min
+  # required ndims. Hence "max_min". Due to rank changing bijectors, we need to
+  # account for synthetic rank growth / synthetic rank decrease from a rank
+  # changing bijector.
+  rank_changed_adjusted_max_min_event_ndims = 0
+
+  if compute_forward:
+    bijector_list = reversed(bijector_list)
+
+  for b in bijector_list:
+    if compute_forward:
+      current_min_event_ndims = b.forward_min_event_ndims
+      current_inverse_min_event_ndims = b.inverse_min_event_ndims
+    else:
+      current_min_event_ndims = b.inverse_min_event_ndims
+      current_inverse_min_event_ndims = b.forward_min_event_ndims
+
+    # New dimensions were touched.
+    if rank_changed_adjusted_max_min_event_ndims < current_min_event_ndims:
+      min_event_ndims += (
+          current_min_event_ndims - rank_changed_adjusted_max_min_event_ndims)
+    rank_changed_adjusted_max_min_event_ndims = max(
+        current_min_event_ndims, rank_changed_adjusted_max_min_event_ndims)
+
+    # If the number of dimensions has increased via forward, then
+    # inverse_min_event_ndims > forward_min_event_ndims, and hence the
+    # dimensions we computed on, have moved left (so we have operated
+    # on additional dimensions).
+    # Conversely, if the number of dimensions has decreased via forward,
+    # then we have inverse_min_event_ndims < forward_min_event_ndims,
+    # and so we will have operated on fewer right most dimensions.
+
+    number_of_changed_dimensions = (
+        current_min_event_ndims - current_inverse_min_event_ndims)
+    rank_changed_adjusted_max_min_event_ndims -= number_of_changed_dimensions
+  return min_event_ndims
+
+
+class Chain(bijector.Bijector):
+  """Bijector which applies a sequence of bijectors.
+
+  Example Use:
+
+  ```python
+  chain = Chain([Exp(), Softplus()], name="one_plus_exp")
+  ```
+
+  Results in:
+
+  * Forward:
+
+   ```python
+   exp = Exp()
+   softplus = Softplus()
+   Chain([exp, softplus]).forward(x)
+   = exp.forward(softplus.forward(x))
+   = tf.exp(tf.log(1. + tf.exp(x)))
+   = 1. + tf.exp(x)
+   ```
+
+  * Inverse:
+
+   ```python
+   exp = Exp()
+   softplus = Softplus()
+   Chain([exp, softplus]).inverse(y)
+   = softplus.inverse(exp.inverse(y))
+   = tf.log(tf.exp(tf.log(y)) - 1.)
+   = tf.log(y - 1.)
+   ```
+
+  """
+
+  def __init__(self, bijectors=None, validate_args=False, name=None):
+    """Instantiates `Chain` bijector.
+
+    Args:
+      bijectors: Python `list` of bijector instances. An empty list makes this
+        bijector equivalent to the `Identity` bijector.
+      validate_args: Python `bool` indicating whether arguments should be
+        checked for correctness.
+      name: Python `str`, name given to ops managed by this object. Default:
+        E.g., `Chain([Exp(), Softplus()]).name == "chain_of_exp_of_softplus"`.
+
+    Raises:
+      ValueError: if bijectors have different dtypes.
+    """
+    if bijectors is None:
+      bijectors = ()
+    self._bijectors = bijectors
+
+    for a_bijector in bijectors:
+      if not a_bijector._is_injective:  # pylint: disable=protected-access
+        raise NotImplementedError(
+            "Invert is not implemented for non-injective bijector ({})".format(
+                a_bijector.name))
+
+    dtype = list(set([b.dtype for b in bijectors if b.dtype is not None]))
+    if len(dtype) > 1:
+      raise ValueError("incompatible dtypes: %s" % dtype)
+    elif len(dtype) == 1:
+      dtype = dtype[0]
+    else:
+      dtype = None
+
+    inverse_min_event_ndims = _compute_min_event_ndims(
+        bijectors, compute_forward=False)
+    forward_min_event_ndims = _compute_min_event_ndims(
+        bijectors, compute_forward=True)
+
+    super(Chain, self).__init__(
+        graph_parents=list(itertools.chain.from_iterable(
+            b.graph_parents for b in bijectors)),
+        forward_min_event_ndims=forward_min_event_ndims,
+        inverse_min_event_ndims=inverse_min_event_ndims,
+        is_constant_jacobian=all(b.is_constant_jacobian for b in bijectors),
+        validate_args=validate_args,
+        dtype=dtype,
+        name=name or ("identity" if not bijectors else
+                      "_of_".join(["chain"] + [b.name for b in bijectors])))
+
+  @property
+  def bijectors(self):
+    return self._bijectors
+
+  def _shape_helper(self, func_name, input_shape, reverse):
+    new_shape = input_shape
+    for b in reversed(self.bijectors) if reverse else self.bijectors:
+      func = getattr(b, func_name, None)
+      if func is None:
+        raise ValueError("unable to call %s on bijector %s (%s)" %
+                         (func_name, b.name, func))
+      new_shape = func(new_shape)
+    return new_shape
+
+  def _forward_event_shape(self, input_shape):
+    return self._shape_helper("forward_event_shape", input_shape,
+                              reverse=True)
+
+  def _forward_event_shape_tensor(self, input_shape):
+    return self._shape_helper(
+        "forward_event_shape_tensor", input_shape, reverse=True)
+
+  def _inverse_event_shape(self, output_shape):
+    return self._shape_helper("inverse_event_shape", output_shape,
+                              reverse=False)
+
+  def _inverse_event_shape_tensor(self, output_shape):
+    return self._shape_helper("inverse_event_shape_tensor", output_shape,
+                              reverse=False)
+
+  def _inverse(self, y, **kwargs):
+    for b in self.bijectors:
+      y = b.inverse(y, **kwargs)
+      # y = b.inverse(y, **kwargs.get(b.name, {}))
+    return y
+
+  def _inverse_log_det_jacobian(self, y, **kwargs):
+    y = tf.convert_to_tensor(value=y, name="y")
+    ildj = tf.cast(0., dtype=dtype_util.base_dtype(y.dtype))
+
+    if not self.bijectors:
+      return ildj
+
+    event_ndims = self._maybe_get_static_event_ndims(
+        self.inverse_min_event_ndims)
+
+    if _use_static_shape(y, event_ndims):
+      event_shape = y.shape[tensorshape_util.rank(y.shape) - event_ndims:]
+    else:
+      event_shape = tf.shape(input=y)[tf.rank(y) - event_ndims:]
+
+    # TODO(b/129973548): Document and simplify.
+    for b in self.bijectors:
+      ildj += b.inverse_log_det_jacobian(
+          y, event_ndims=event_ndims, **kwargs)#.get(b.name, {}))
+
+      if _use_static_shape(y, event_ndims):
+        event_shape = b.inverse_event_shape(event_shape)
+        event_ndims = self._maybe_get_static_event_ndims(
+            tensorshape_util.rank(event_shape))
+      else:
+        event_shape = b.inverse_event_shape_tensor(event_shape)
+        event_shape_ = distribution_util.maybe_get_static_value(event_shape)
+        event_ndims = tf.size(input=event_shape)
+        event_ndims_ = self._maybe_get_static_event_ndims(event_ndims)
+
+        if event_ndims_ is not None and event_shape_ is not None:
+          event_ndims = event_ndims_
+          event_shape = event_shape_
+
+      # y = b.inverse(y, **kwargs.get(b.name, {}))
+      y = b.inverse(y, **kwargs)
+    return ildj
+
+  def _forward(self, x, **kwargs):
+    for b in reversed(self.bijectors):
+      # print(kwargs)
+      # print(kwargs.get(b.name, {}))
+      # x = b.forward(x, **kwargs.get(b.name, {}))
+      print(b)
+      print('in chain.py', kwargs)
+      x = b.forward(x, **kwargs)
+    return x
+
+  def _forward_log_det_jacobian(self, x, **kwargs):
+    x = tf.convert_to_tensor(value=x, name="x")
+
+    fldj = tf.cast(0., dtype=dtype_util.base_dtype(x.dtype))
+
+    if not self.bijectors:
+      return fldj
+
+    event_ndims = self._maybe_get_static_event_ndims(
+        self.forward_min_event_ndims)
+
+    if _use_static_shape(x, event_ndims):
+      event_shape = x.shape[tensorshape_util.rank(x.shape) - event_ndims:]
+    else:
+      event_shape = tf.shape(input=x)[tf.rank(x) - event_ndims:]
+
+    # TODO(b/129973548): Document and simplify.
+    for b in reversed(self.bijectors):
+      fldj += b.forward_log_det_jacobian(
+          x, event_ndims=event_ndims, **kwargs)#.get(b.name, {}))
+      if _use_static_shape(x, event_ndims):
+        event_shape = b.forward_event_shape(event_shape)
+        event_ndims = self._maybe_get_static_event_ndims(
+            tensorshape_util.rank(event_shape))
+      else:
+        event_shape = b.forward_event_shape_tensor(event_shape)
+        event_shape_ = distribution_util.maybe_get_static_value(event_shape)
+        event_ndims = tf.size(input=event_shape)
+        event_ndims_ = self._maybe_get_static_event_ndims(event_ndims)
+
+        if event_ndims_ is not None and event_shape_ is not None:
+          event_ndims = event_ndims_
+          event_shape = event_shape_
+
+      # print(kwargs)
+      # print(kwargs.get(b.name, {}))
+      # x = b.forward(x, **kwargs.get(b.name, {}))
+      x = b.forward(x, **kwargs)
+    return fldj

--- a/gems/flows/chain.py
+++ b/gems/flows/chain.py
@@ -269,11 +269,7 @@ class Chain(bijector.Bijector):
 
   def _forward(self, x, **kwargs):
     for b in reversed(self.bijectors):
-      # print(kwargs)
-      # print(kwargs.get(b.name, {}))
       # x = b.forward(x, **kwargs.get(b.name, {}))
-      print(b)
-      print('in chain.py', kwargs)
       x = b.forward(x, **kwargs)
     return x
 
@@ -311,8 +307,6 @@ class Chain(bijector.Bijector):
           event_ndims = event_ndims_
           event_shape = event_shape_
 
-      # print(kwargs)
-      # print(kwargs.get(b.name, {}))
       # x = b.forward(x, **kwargs.get(b.name, {}))
       x = b.forward(x, **kwargs)
     return fldj

--- a/gems/flows/joint_distribution.py
+++ b/gems/flows/joint_distribution.py
@@ -1,0 +1,341 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""The `JointDistribution` base class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import six
+
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.distributions import distribution as distribution_lib
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow_probability.python.internal import tensorshape_util
+
+
+__all__ = [
+    'JointDistribution',
+]
+
+
+@six.add_metaclass(abc.ABCMeta)
+class JointDistribution(distribution_lib.Distribution):
+  """Joint distribution over one or more component distributions.
+
+  This distribution enables both sampling and joint probability computation from
+  a single model specification.
+
+  A joint distribution is a collection of possibly interdependent distributions.
+
+  **Note**: unlike other non-`JointDistribution` distributions in
+  `tfp.distributions`, `JointDistribution.sample` (and subclasses) return a
+  structure of  `Tensor`s rather than a `Tensor`.  A structure can be a `list`,
+  `tuple`, `dict`, `collections.namedtuple`, etc. Accordingly
+  `joint.batch_shape` returns a structure of `TensorShape`s for each of the
+  distributions' batch shapes and `joint.batch_shape_tensor()` returns a
+  structure of `Tensor`s for each of the distributions' event shapes. (Same with
+  `event_shape` analogues.)
+
+  #### Subclass Requirements
+
+  Subclasses implement:
+
+  - `_flat_sample_distributions`: returns two `list`-likes: the first being a
+    sequence of `Distribution`-like instances the second being a sequence of
+    `Tensor` samples, each one drawn from its corresponding `Distribution`-like
+    instance. The optional `value` argument is either `None` or a `list`-like
+    with the same `len` as either of the results.
+
+  - `_flatten`: takes a structured input and returns a sequence.
+
+  - `_unflatten`: takes a sequence and returns a structure matching the
+    semantics of the `JointDistribution` subclass.
+
+  Subclasses initialize:
+
+  - `_most_recently_built_distributions`: an iterable sequence of distributions
+    which are known at `__init__` or `None`.
+  """
+
+  @property
+  def model(self):
+    return self._model
+
+  @abc.abstractmethod
+  def _flat_sample_distributions(self, sample_shape=(), seed=None, value=None):
+    raise NotImplementedError()
+
+  @abc.abstractmethod
+  def _unflatten(self, xs):
+    raise NotImplementedError()
+
+  @abc.abstractmethod
+  def _flatten(self, xs):
+    raise NotImplementedError()
+
+  @property
+  def dtype(self):
+    """The `DType` of `Tensor`s handled by this `Distribution`."""
+    if self._most_recently_built_distributions is None:
+      return super(JointDistribution, self).dtype
+    return self._unflatten(
+        None if d is None else d.dtype
+        for d in self._most_recently_built_distributions)
+
+  @property
+  def reparameterization_type(self):
+    """Describes how samples from the distribution are reparameterized.
+
+    Currently this is one of the static instances
+    `tfd.FULLY_REPARAMETERIZED` or `tfd.NOT_REPARAMETERIZED`.
+
+    Returns:
+      reparameterization_type: `ReparameterizationType` of each distribution in
+        `model`.
+    """
+    if self._most_recently_built_distributions is None:
+      return None
+    return self._unflatten(
+        None if d is None else d.reparameterization_type
+        for d in self._most_recently_built_distributions)
+
+  @property
+  def batch_shape(self):
+    """Shape of a single sample from a single event index as a `TensorShape`.
+
+    May be partially defined or unknown.
+
+    The batch dimensions are indexes into independent, non-identical
+    parameterizations of this distribution.
+
+    Returns:
+      batch_shape: `tuple` of `TensorShape`s representing the `batch_shape` for
+        each distribution in `model`.
+    """
+    # The following cannot leak graph Tensors in eager because `batch_shape` is
+    # a `TensorShape`.
+    if self._most_recently_built_distributions is None:
+      return None
+    return self._unflatten(
+        tf.TensorShape(None) if d is None else d.batch_shape
+        for d in self._most_recently_built_distributions)
+
+  def batch_shape_tensor(self, name='batch_shape_tensor'):
+    """Shape of a single sample from a single event index as a 1-D `Tensor`.
+
+    The batch dimensions are indexes into independent, non-identical
+    parameterizations of this distribution.
+
+    Args:
+      name: name to give to the op
+
+    Returns:
+      batch_shape: `Tensor` representing batch shape of each distribution in
+        `model`.
+    """
+    with self._name_scope(name):
+      return self._unflatten(self._map_attr_over_dists('batch_shape_tensor')[1])
+
+  @property
+  def event_shape(self):
+    """Shape of a single sample from a single batch as a `TensorShape`.
+
+    May be partially defined or unknown.
+
+    Returns:
+      event_shape: `tuple` of `TensorShape`s representing the `event_shape` for
+        each distribution in `model`.
+    """
+    # The following cannot leak graph Tensors in eager because `batch_shape` is
+    # a `TensorShape`.
+    if self._most_recently_built_distributions is None:
+      return None
+    return self._unflatten(
+        tf.TensorShape(None) if d is None else d.event_shape
+        for d in self._most_recently_built_distributions)
+
+  def event_shape_tensor(self, name='event_shape_tensor'):
+    """Shape of a single sample from a single batch as a 1-D int32 `Tensor`.
+
+    Args:
+      name: name to give to the op
+
+    Returns:
+      event_shape: `tuple` of `Tensor`s representing the `event_shape` for each
+        distribution in `model`.
+    """
+    with self._name_scope(name):
+      return self._unflatten(self._map_attr_over_dists('event_shape_tensor')[1])
+
+  def sample_distributions(self, sample_shape=(), seed=None, value=None,
+                           name='sample_distributions'):
+    """Generate samples and the (random) distributions.
+
+    Note that a call to `sample()` without arguments will generate a single
+    sample.
+
+    Args:
+      sample_shape: 0D or 1D `int32` `Tensor`. Shape of the generated samples.
+      seed: Python integer seed for generating random numbers.
+      value: `list` of `Tensor`s in `distribution_fn` order to use to
+        parameterize other ("downstream") distribution makers.
+        Default value: `None` (i.e., draw a sample from each distribution).
+      name: name prepended to ops created by this function.
+        Default value: `"sample_distributions"`.
+
+    Returns:
+      distributions: a `tuple` of `Distribution` instances for each of
+        `distribution_fn`.
+      samples: a `tuple` of `Tensor`s with prepended dimensions `sample_shape`
+        for each of `distribution_fn`.
+    """
+    with self._name_scope(name):
+      ds, xs = self._call_flat_sample_distributions(sample_shape, seed, value)
+      return self._unflatten(ds), self._unflatten(xs)
+
+  def log_prob_parts(self, value, name='log_prob_parts'):
+    """Log probability density/mass function.
+
+    Args:
+      value: `list` of `Tensor`s in `distribution_fn` order for which we compute
+        the `log_prob_parts` and to parameterize other ("downstream")
+        distributions.
+      name: name prepended to ops created by this function.
+        Default value: `"log_prob_parts"`.
+
+    Returns:
+      log_prob_parts: a `tuple` of `Tensor`s representing the `log_prob` for
+        each `distribution_fn` evaluated at each corresponding `value`.
+    """
+    with self._name_scope(name):
+      _, xs = self._map_measure_over_dists('log_prob', value)
+      return self._unflatten(xs)
+
+  def prob_parts(self, value, name='prob_parts'):
+    """Log probability density/mass function.
+
+    Args:
+      value: `list` of `Tensor`s in `distribution_fn` order for which we compute
+        the `prob_parts` and to parameterize other ("downstream") distributions.
+      name: name prepended to ops created by this function.
+        Default value: `"prob_parts"`.
+
+    Returns:
+      prob_parts: a `tuple` of `Tensor`s representing the `prob` for
+        each `distribution_fn` evaluated at each corresponding `value`.
+    """
+    with self._name_scope(name):
+      _, xs = self._map_measure_over_dists('prob', value)
+      return self._unflatten(xs)
+
+  def is_scalar_event(self, name='is_scalar_event'):
+    """Indicates that `event_shape == []`.
+
+    Args:
+      name: Python `str` prepended to names of ops created by this function.
+
+    Returns:
+      is_scalar_event: `bool` scalar `Tensor` for each distribution in `model`.
+    """
+    with self._name_scope(name):
+      return self._unflatten(self._map_attr_over_dists('is_scalar_event')[1])
+
+  def is_scalar_batch(self, name='is_scalar_batch'):
+    """Indicates that `batch_shape == []`.
+
+    Args:
+      name: Python `str` prepended to names of ops created by this function.
+
+    Returns:
+      is_scalar_batch: `bool` scalar `Tensor` for each distribution in `model`.
+    """
+    with self._name_scope(name):
+      return self._unflatten(self._map_attr_over_dists('is_scalar_batch')[1])
+
+  def _log_prob(self, value):
+    _, xs = self._map_measure_over_dists('log_prob', value)
+    return sum(xs)
+
+  @distribution_util.AppendDocstring(kwargs_dict={
+      'value': ('`Tensor`s structured like `type(model)` used to parameterize '
+                'other dependent ("downstream") distribution-making functions. '
+                'Using `None` for any element will trigger a sample from the '
+                'corresponding distribution. Default value: `None` '
+                '(i.e., draw a sample from each distribution).')})
+  def _sample_n(self, sample_shape, seed, value=None):
+    _, xs = self._call_flat_sample_distributions(sample_shape, seed, value)
+    return self._unflatten(xs)
+
+  def _map_measure_over_dists(self, attr, value):
+    if any(x is None for x in tf.nest.flatten(value)):
+      raise ValueError('No `value` part can be `None`; saw: {}.'.format(value))
+    ds, xs = self._call_flat_sample_distributions(value=value)
+    return ds, maybe_check_wont_broadcast(
+        (getattr(d, attr)(x) for d, x in zip(ds, xs)),
+        self.validate_args)
+
+  def _map_attr_over_dists(self, attr):
+    if (not self._most_recently_built_distributions or
+        any(d is None for d in self._most_recently_built_distributions)):
+      # Same seed to help CSE.
+      ds, _ = self._call_flat_sample_distributions(seed=42)
+    else:
+      ds = self._most_recently_built_distributions
+    return ds, (None if d is None else getattr(d, attr)() for d in ds)
+
+  def _call_flat_sample_distributions(
+      self, sample_shape=(), seed=None, value=None):
+    if value is not None:
+      value = self._flatten(value)
+    ds, xs = self._flat_sample_distributions(sample_shape, seed, value)
+    if not value:
+      self._most_recently_built_distributions = tuple(ds)
+    return ds, xs
+
+  # We need to bypass base Distribution reshaping/validation logic so we
+  # tactically implement a few of the `_call_*` redirectors.  We don't want to
+  # override the public level because then tfp.layers can't take generic
+  # `Distribution.foo` as argument for the `convert_to_tensor_fn` parameter.
+  def _call_log_prob(self, value, name):
+    with self._name_scope(name):
+      return self._log_prob(value)
+
+  def _call_sample_n(self, sample_shape, seed, name, value=None):
+    with self._name_scope(name):
+      return self._sample_n(sample_shape, seed, value)
+
+
+def maybe_check_wont_broadcast(flat_xs, validate_args):
+  """Verifies that `parts` don't broadcast."""
+  flat_xs = tuple(flat_xs)  # So we can receive generators.
+  if not validate_args:
+    # Note: we don't try static validation because it is theoretically
+    # possible that a user wants to take advantage of broadcasting.
+    # Only when `validate_args` is `True` do we enforce the validation.
+    return flat_xs
+  msg = 'Broadcasting probably indicates an error in model specification.'
+  s = tuple(x.shape for x in flat_xs)
+  if all(tensorshape_util.is_fully_defined(s_) for s_ in s):
+    if not all(a == b for a, b in zip(s[1:], s[:-1])):
+      raise ValueError(msg)
+    return flat_xs
+  assertions = [assert_util.assert_equal(a, b, message=msg)
+                for a, b in zip(s[1:], s[:-1])]
+  with tf.control_dependencies(assertions):
+    return tuple(tf.identity(x) for x in flat_xs)

--- a/gems/flows/joint_distribution_named.py
+++ b/gems/flows/joint_distribution_named.py
@@ -1,0 +1,256 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""The `JointDistributionNamed` class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+
+from gems.flows import joint_distribution_sequential
+from tensorflow_probability.python.internal import distribution_util
+
+
+__all__ = [
+    'JointDistributionNamed',
+]
+
+
+class JointDistributionNamed(
+    joint_distribution_sequential.JointDistributionSequential):
+  """Joint distribution parameterized by named distribution-making functions.
+  This distribution enables both sampling and joint probability computation from
+  a single model specification.
+  A joint distribution is a collection of possibly interdependent distributions.
+  Like `JointDistributionSequential`, `JointDistributionNamed` is parameterized
+  by several distribution-making functions. Unlike `JointDistributionNamed`,
+  each distribution-making function must have its own key. Additionally every
+  distribution-making function's arguments must refer to only specified keys.
+  #### Mathematical Details
+  Internally `JointDistributionNamed` implements the chain rule of probability.
+  That is, the probability function of a length-`d` vector `x` is,
+  ```none
+  p(x) = prod{ p(x[i] | x[:i]) : i = 0, ..., (d - 1) }
+  ```
+  The `JointDistributionNamed` is parameterized by a `dict` (or `namedtuple`)
+  composed of either:
+  1. `tfp.distributions.Distribution`-like instances or,
+  2. `callable`s which return a `tfp.distributions.Distribution`-like instance.
+  The "conditioned on" elements are represented by the `callable`'s required
+  arguments; every argument must correspond to a key in the named
+  distribution-making functions. Distribution-makers which are directly a
+  `Distribution`-like instance are allowed for convenience and semantically
+  identical a zero argument `callable`. When the maker takes no arguments it is
+  preferable to directly provide the distribution instance.
+  #### Examples
+  ```python
+  tfd = tfp.distributions
+  # Consider the following generative model:
+  #     e ~ Exponential(rate=[100,120])
+  #     g ~ Gamma(concentration=e[0], rate=e[1])
+  #     n ~ Normal(loc=0, scale=2.)
+  #     m ~ Normal(loc=n, scale=g)
+  #     for i = 1, ..., 12:
+  #       x[i] ~ Bernoulli(logits=m)
+  # In TFP, we can write this as:
+  joint = tfd.JointDistributionNamed(dict(
+      e=             tfd.Independent(tfd.Exponential(rate=[100, 120]), 1),
+      g=lambda    e: tfd.Gamma(concentration=e[..., 0], rate=e[..., 1]),
+      n=             tfd.Normal(loc=0, scale=2.),
+      m=lambda n, g: tfd.Normal(loc=n, scale=g),
+      x=lambda    m: tfd.Sample(tfd.Bernoulli(logits=m), 12),
+  ))
+  # Notice the 1:1 correspondence between "math" and "code". Further, notice
+  # that unlike `JointDistributionSequential`, there is no need to put the
+  # distribution-making functions in topologically sorted order nor is it ever
+  # necessary to use dummy arguments to skip dependencies.
+  x = joint.sample()
+  # ==> A 5-element `dict` of tfd.Distribution instances.
+  joint.log_prob(x)
+  # ==> A scalar `Tensor` representing the total log prob under all five
+  #     distributions.
+  joint._resolve_graph()
+  # ==> (('e', ()),
+  #      ('g', ('e',)),
+  #      ('n', ()),
+  #      ('m', ('n', 'g')),
+  #      ('x', ('m',)))
+  ```
+  #### Discussion
+  `JointDistributionNamed` topologically sorts the distribution-making functions
+  and calls each by feeding in all previously created dependencies. A
+  distribution-maker must either be a:
+  1. `tfd.Distribution`-like instance (e.g., `e` and `n` in the above example),
+  2. Python `callable` (e.g., `g`, `m`, `x` in the above example).
+  Regarding #1, an object is deemed "`tfd.Distribution`-like" if it has a
+  `sample`, `log_prob`, and distribution properties, e.g., `batch_shape`,
+  `event_shape`, `dtype`.
+  Regarding #2, in addition to using a function (or `lambda`), supplying a TFD
+  "`class`" is also permissible, this also being a "Python `callable`." For
+  example, instead of writing:
+  `lambda loc, scale: tfd.Normal(loc=loc, scale=scale)`
+  one could have simply written `tfd.Normal`.
+  Notice that directly providing a `tfd.Distribution`-like instance means there
+  cannot exist a (dynamic) dependency on other distributions; it is
+  "independent" both "computationally" and "statistically." The same is
+  self-evidently true of zero-argument `callable`s.
+  A distribution instance depends on other distribution instances through the
+  distribution making function's *required arguments*. The distribution makers'
+  arguments are parameterized by samples from the corresponding previously
+  constructed distributions. ("Previous" in the sense of a topological sorting
+  of dependencies.)
+  **Note**: unlike other non-`JointDistribution` distributions in
+  `tfp.distributions`, `JointDistribution.sample` (and subclasses) return a
+  structure of  `Tensor`s rather than a `Tensor`.  A structure can be a `list`,
+  `tuple`, `dict`, `collections.namedtuple`, etc. Accordingly
+  `joint.batch_shape` returns a structure of `TensorShape`s for each of the
+  distributions' batch shapes and `joint.batch_shape_tensor()` returns a
+  structure of `Tensor`s for each of the distributions' event shapes. (Same with
+  `event_shape` analogues.)
+  **Note**: unlike other non-`JointDistribution` distributions in
+  `tfp.distributions`, `JointDistributionNamed.sample` (and subclasses) return a
+  structure of  `Tensor`s rather than a `Tensor`.  A structure can be anything
+  which is convertible to `dict`. This can be a `dict`,
+  `collections.namedtuple`, etc. Accordingly `joint.batch_shape` returns a
+  structure of `TensorShape`s for each of the distributions' batch shapes and
+  `joint.batch_shape_tensor()` returns a structure of `Tensor`s for each of the
+  distributions' event shapes. (Same with `event_shape` analogues.)
+  """
+
+  def __init__(self, model, validate_args=False, name=None):
+    """Construct the `JointDistributionNamed` distribution.
+    Args:
+      model: Python `dict` or `namedtuple` of distribution-making functions each
+        with required args corresponding only to other keys.
+      validate_args: Python `bool`.  Whether to validate input with asserts.
+        If `validate_args` is `False`, and the inputs are invalid,
+        correct behavior is not guaranteed.
+        Default value: `False`.
+      name: The name for ops managed by the distribution.
+        Default value: `None` (i.e., `"JointDistributionNamed"`).
+    """
+    super(JointDistributionNamed, self).__init__(
+        model, validate_args, name or 'JointDistributionNamed')
+
+  def _build(self, model):
+    """Creates `dist_fn`, `dist_fn_wrapped`, `dist_fn_args`, `dist_fn_name`."""
+    if not _is_dict_like(model):
+      raise TypeError('`model` must be convertible to `dict` (saw: {}).'.format(
+          type(model).__name__))
+    [
+        self._dist_fn,
+        self._dist_fn_wrapped,
+        self._dist_fn_args,
+        self._dist_fn_name,  # JointDistributionSequential doesn't have this.
+    ] = _prob_chain_rule_flatten(model)
+
+  def _unflatten(self, xs):
+    kwargs = dict(zip(self._dist_fn_name, tuple(xs)))
+    return type(self.model)(**kwargs)
+
+  def _flatten(self, xs):
+    if xs is None:
+      return (None,) * len(self._dist_fn_name)
+    if hasattr(xs, 'get'):
+      return tuple(xs.get(n, None) for n in self._dist_fn_name)
+    return tuple(getattr(xs, n) for n in self._dist_fn_name)
+
+  def _resolve_graph(self, distribution_names=None, leaf_name='x'):
+    return tuple(zip(self._dist_fn_name,
+                     [() if x is None else x
+                      for x in self._dist_fn_args]))
+
+
+class _Node(object):
+
+  def __init__(self, name, parents):
+    self.name = name
+    self.parents = parents
+    self.depth = -1
+
+
+def _depth(g):
+  """Computes the number of edges on longest path from node to root."""
+  def _explore(v):
+    if v.depth < 0:
+      v.depth = ((1 + max([-1] + [_explore(annotated_graph[u])
+                                  for u in v.parents]))
+                 if v.parents else 0)
+    return v.depth
+  annotated_graph = {k: _Node(k, v) for k, v in g.items()}
+  for v in annotated_graph.values():
+    _explore(v)
+  return annotated_graph
+
+
+def _best_order(g):
+  """Creates tuple of str tuple-str pairs representing resolved & sorted DAG."""
+  def _explore(u):
+    """Recursive function to ascend up through unvisited dependencies."""
+    if u.depth < 0:
+      return  # Already visited.
+    if not u.parents:
+      result.append((u.name, u.parents))
+      u.depth = -1  # Mark visited.
+      return
+    u.depth = -1  # Mark visited.
+    for v in sorted((g.get(p) for p in u.parents),
+                    key=lambda v: (v.depth, v.name), reverse=True):
+      _explore(v)
+    result.append((u.name, u.parents))
+  g = _depth(g)
+  result = []
+  for u in sorted(g.values(), key=lambda v: (v.depth, v.name), reverse=True):
+    _explore(u)
+  return tuple(result)
+
+
+def _prob_chain_rule_flatten(named_makers):
+  """Creates lists of callables suitable for JDSeq."""
+  def _make(dist_fn, args):
+    if args is None:
+      return lambda *_: dist_fn
+    if not args:
+      return lambda *_: dist_fn()
+    def _fn(*xs):
+      kwargs = dict([(k, v) for k, v in zip(dist_fn_name, xs) if k in args])
+      return dist_fn(**kwargs)
+    return _fn
+  named_makers = _convert_to_dict(named_makers)
+  g = {k: None if distribution_util.is_distribution_instance(v)
+          else joint_distribution_sequential._get_required_args(v)  # pylint: disable=protected-access
+       for k, v in named_makers.items()}
+  g = _best_order(g)
+  dist_fn_name, dist_fn_args = zip(*g)
+  dist_fn_args = tuple(None if a is None else tuple(a) for a in dist_fn_args)
+  dist_fn_wrapped = tuple(_make(named_makers[name], parents)
+                          for (name, parents) in g)
+  dist_fn = tuple(named_makers.get(n) for n in dist_fn_name)
+  return dist_fn, dist_fn_wrapped, dist_fn_args, dist_fn_name
+
+
+def _is_dict_like(x):
+  """Returns `True` if input is convertible to `dict`, `False` otherwise."""
+  if hasattr(x, '_asdict'):
+    return True
+  return isinstance(x, collections.Mapping)
+
+
+def _convert_to_dict(x):
+  """Converts input to `dict`."""
+  if hasattr(x, '_asdict'):
+    return x._asdict()
+  return dict(x)

--- a/gems/flows/joint_distribution_sequential.py
+++ b/gems/flows/joint_distribution_sequential.py
@@ -1,0 +1,525 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""The `JointDistributionSequential` class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import functools
+
+import tensorflow.compat.v2 as tf
+
+# from tensorflow_probability.python.distributions import joint_distribution as joint_distribution_lib
+from gems.flows import joint_distribution as joint_distribution_lib
+from tensorflow_probability.python.distributions import kullback_leibler
+from tensorflow_probability.python.distributions import seed_stream
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow.python.util import tf_inspect  # pylint: disable=g-direct-tensorflow-import
+
+
+__all__ = [
+    'JointDistributionSequential',
+]
+
+
+def _make_summary_statistic(attr):
+  """Factory for making summary statistics, eg, mean, mode, stddev."""
+  def _fn(self):
+    if any(self._dist_fn_args):  # pylint: disable=protected-access
+      raise ValueError(
+          'Can only compute ' + attr + ' when all distributions are '
+          'independent; {}'.format(self.model))
+    return self._unflatten(getattr(d(), attr)() for d in self._dist_fn_wrapped)  # pylint: disable=protected-access
+  return _fn
+
+
+class JointDistributionSequential(joint_distribution_lib.JointDistribution):
+  """Joint distribution parameterized by distribution-making functions.
+
+  This distribution enables both sampling and joint probability computation from
+  a single model specification.
+
+  A joint distribution is a collection of possibly interdependent distributions.
+  Like `tf.keras.Sequential`, the `JointDistributionSequential` can be specified
+  via a `list` of functions (each responsible for making a
+  `tfp.distributions.Distribution`-like instance).  Unlike
+  `tf.keras.Sequential`, each function can depend on the output of all previous
+  elements rather than only the immediately previous.
+
+  #### Mathematical Details
+
+  The `JointDistributionSequential` implements the chain rule of probability.
+  That is, the probability function of a length-`d` vector `x` is,
+
+  ```none
+  p(x) = prod{ p(x[i] | x[:i]) : i = 0, ..., (d - 1) }
+  ```
+
+  The `JointDistributionSequential` is parameterized by a `list` comprised of
+  either:
+
+  1. `tfp.distributions.Distribution`-like instances or,
+  2. `callable`s which return a `tfp.distributions.Distribution`-like instance.
+
+  Each `list` element implements the `i`-th *full conditional distribution*,
+  `p(x[i] | x[:i])`. The "conditioned on" elements are represented by the
+  `callable`'s required arguments. Directly providing a `Distribution`-like
+  instance is a convenience and is semantically identical a zero argument
+  `callable`.
+
+  Denote the `i`-th `callable`s non-default arguments as `args[i]`. Since the
+  `callable` is the conditional manifest, `0 <= len(args[i]) <= i - 1`. When
+  `len(args[i]) < i - 1`, the `callable` only depends on a subset of the
+  previous distributions, specifically those at indexes:
+  `range(i - 1, i - 1 - num_args[i], -1)`.
+  (See "Examples" and "Discussion" for why the order is reversed.)
+
+  #### Examples
+
+  ```python
+  tfd = tfp.distributions
+
+  # Consider the following generative model:
+  #     e ~ Exponential(rate=[100,120])
+  #     g ~ Gamma(concentration=e[0], rate=e[1])
+  #     n ~ Normal(loc=0, scale=2.)
+  #     m ~ Normal(loc=n, scale=g)
+  #     for i = 1, ..., 12:
+  #       x[i] ~ Bernoulli(logits=m)
+
+  # In TFP, we can write this as:
+  joint = tfd.JointDistributionSequential([
+                   tfd.Independent(tfd.Exponential(rate=[100, 120]), 1),  # e
+      lambda    e: tfd.Gamma(concentration=e[..., 0], rate=e[..., 1]),    # g
+                   tfd.Normal(loc=0, scale=2.),                           # n
+      lambda n, g: tfd.Normal(loc=n, scale=g)                             # m
+      lambda    m: tfd.Sample(tfd.Bernoulli(logits=m), 12)                # x
+  ])
+  # (Notice the 1:1 correspondence between "math" and "code".)
+
+  x = joint.sample()
+  # ==> A length-5 list of Tensors
+  joint.log_prob(x)
+  # ==> A scalar `Tensor` representing the total log prob under all five
+  #     distributions.
+
+  joint._resolve_graph()
+  # ==> (('e', ()),
+  #      ('g', ('e',)),
+  #      ('n', ()),
+  #      ('m', ('n', 'g')),
+  #      ('x', ('m',)))
+  ```
+
+  #### Discussion
+
+  `JointDistributionSequential` builds each distribution in `list` order; list
+  items must be either a:
+
+  1. `tfd.Distribution`-like instance (e.g., `e` and `n`), or a
+  2. Python `callable` (e.g., `g`, `m`, `x`).
+
+  Regarding #1, an object is deemed "`tfd.Distribution`-like" if it has a
+  `sample`, `log_prob`, and distribution properties, e.g., `batch_shape`,
+  `event_shape`, `dtype`.
+
+  Regarding #2, in addition to using a function (or `lambda`), supplying a TFD
+  "`class`" is also permissible, this also being a "Python `callable`." For
+  example, instead of writing:
+  `lambda loc, scale: tfd.Normal(loc=loc, scale=scale)`
+  one could have simply written `tfd.Normal`.
+
+  Notice that directly providing a `tfd.Distribution`-like instance means there
+  cannot exist a (dynamic) dependency on other distributions; it is
+  "independent" both "computationally" and "statistically." The same is
+  self-evidently true of zero-argument `callable`s.
+
+  A distribution instance depends on other distribution instances through the
+  distribution making function's *required arguments*. If the distribution maker
+  has `k` required arguments then the `JointDistributionSequential` calls the
+  maker with samples produced by the previous `k` distributions.
+
+  **Note**: **maker arguments are provided in reverse order** of the previous
+  elements in the list. In the example, notice that `m` depends on `n` and `g`
+  in this order. The order is reversed for convenience. We reverse arguments
+  under the heuristic observation that many graphical models have chain-like
+  dependencies which are self-evidently topologically sorted from the human
+  cognitive process of postulating the generative process. By feeding the
+  previous num required args in reverse order we (often) enable a simpler maker
+  function signature. If the maker needs to depend on distribution previous to
+  one which is not a dependency, one must use a dummy arg, to "gobble up" the
+  unused dependency, e.g.,
+  `lambda _ignore, actual_dependency: SomeDistribution(actual_dependency)`.
+
+  **Note**: unlike other non-`JointDistribution` distributions in
+  `tfp.distributions`, `JointDistribution.sample` (and subclasses) return a
+  structure of  `Tensor`s rather than a `Tensor`.  A structure can be anything
+  which is `list`-like, e.g., a `list` or `tuple` of `distribution` makers.
+  Accordingly `joint.batch_shape` returns a `list`-like structure of
+  `TensorShape`s for each of the distributions' batch shapes and
+  `joint.batch_shape_tensor()` returns a `list`-like structure of `Tensor`s for
+  each of the distributions' event shapes. (Same with `event_shape` analogues.)
+  """
+
+  def __init__(self, model, validate_args=False, name=None):
+    """Construct the `JointDistributionSequential` distribution.
+
+    Args:
+      model: Python list of either tfd.Distribution instances and/or
+        lambda functions which take the `k` previous distributions and returns a
+        new tfd.Distribution instance.
+      validate_args: Python `bool`.  Whether to validate input with asserts.
+        If `validate_args` is `False`, and the inputs are invalid,
+        correct behavior is not guaranteed.
+        Default value: `False`.
+      name: The name for ops managed by the distribution.
+        Default value: `None` (i.e., `"JointDistributionSequential"`).
+    """
+    parameters = dict(locals())
+    with tf.name_scope(name or 'JointDistributionSequential') as name:
+      self._model = model
+      self._build(model)
+      self._most_recently_built_distributions = [
+          None if a else d() for d, a
+          in zip(self._dist_fn_wrapped, self._dist_fn_args)]
+      self._always_use_specified_sample_shape = False
+      super(JointDistributionSequential, self).__init__(
+          dtype=None,  # Ignored; we'll override.
+          reparameterization_type=None,  # Ignored; we'll override.
+          validate_args=validate_args,
+          allow_nan_stats=False,
+          parameters=parameters,
+          graph_parents=[],
+          name=name)
+      # Check valid structure.
+      self._unflatten(self._flatten(model))
+
+  def _build(self, model):
+    """Creates `dist_fn`, `dist_fn_wrapped`, `dist_fn_args`."""
+    if not isinstance(model, collections.Sequence):
+      raise TypeError('`model` must be `list`-like (saw: {}).'.format(
+          type(model).__name__))
+    self._dist_fn = model
+    self._dist_fn_wrapped, self._dist_fn_args = zip(*[
+        _unify_call_signature(i, dist_fn)
+        for i, dist_fn in enumerate(model)])
+
+  def _flat_sample_distributions(self, sample_shape=(), seed=None, value=None):
+    # This function additionally depends on:
+    #   self._dist_fn_wrapped
+    #   self._dist_fn_args
+    #   self._always_use_specified_sample_shape
+    seed = seed_stream.SeedStream('JointDistributionSequential', seed)
+    ds = []
+    xs = [None]*len(self._dist_fn_wrapped) if value is None else list(value)
+    if len(xs) != len(self._dist_fn_wrapped):
+      raise ValueError('Number of `xs`s must match number of '
+                       'distributions.')
+    for i, (dist_fn, args) in enumerate(zip(self._dist_fn_wrapped,
+                                            self._dist_fn_args)):
+      ds.append(dist_fn(*xs[:i]))  # Chain rule of probability.
+      if xs[i] is None:
+        # TODO(b/129364796): We should ignore args prefixed with `_`; this
+        # would mean we more often identify when to use `sample_shape=()`
+        # rather than `sample_shape=sample_shape`.
+        # xs[i] = ds[-1].sample(
+        #     () if args and not self._always_use_specified_sample_shape
+        #     else sample_shape, seed=seed())
+        xs[i] = ds[-1].sample(sample_shape, seed=seed())
+      else:
+        xs[i] = tf.convert_to_tensor(value=xs[i], dtype_hint=ds[-1].dtype)
+        seed()  # Ensure reproducibility even when xs are (partially) set.
+    # Note: we could also resolve distributions up to the first non-`None` in
+    # `self._flatten(value)`, however we omit this feature for simplicity,
+    # speed, and because it has not yet been requested.
+    return ds, xs
+
+  def _unflatten(self, xs):
+    try:
+      return type(self.model)(xs)
+    except TypeError:
+      raise TypeError(
+          'Unable to unflatten like `model` with type "{}".'.format(
+              type(self.model).__name__))
+
+  def _flatten(self, xs):
+    if xs is None:
+      return (None,) * len(self._dist_fn_wrapped)
+    try:
+      xs = tuple(xs)
+    except TypeError:
+      raise TypeError(
+          'Unable to flatten like `model` with type "{}".'.format(
+              type(self.model).__name__))
+    return xs + (None,)*(len(self._dist_fn_args) - len(xs))
+
+  def _call_attr(self, attr):
+    if any(self._dist_fn_args):
+      # Const seed for maybe CSE.
+      ds, _ = self._flat_sample_distributions(seed=42)
+    else:
+      ds = tuple(d() for d in self._dist_fn_wrapped)
+    return (getattr(d, attr)() for d in ds)
+
+  def _resolve_graph(self, distribution_names=None, leaf_name='x'):
+    """Creates a `tuple` of `tuple`s of dependencies.
+
+    This function is **experimental**. That said, we encourage its use
+    and ask that you report problems to `tfprobability@tensorflow.org`.
+
+    Args:
+      distribution_names: `list` of `str` or `None` names corresponding to each
+        of `model` elements. (`None`s are expanding into the
+        appropriate `str`.)
+      leaf_name: `str` used when no maker depends on a particular
+        `model` element.
+
+    Returns:
+      graph: `tuple` of `(str tuple)` pairs representing the name of each
+        distribution (maker) and the names of its dependencies.
+
+    #### Example
+
+    ```python
+    d = tfd.JointDistributionSequential([
+                     tfd.Independent(tfd.Exponential(rate=[100, 120]), 1),
+        lambda    e: tfd.Gamma(concentration=e[..., 0], rate=e[..., 1]),
+                     tfd.Normal(loc=0, scale=2.),
+        lambda n, g: tfd.Normal(loc=n, scale=g),
+    ])
+    d._resolve_graph()
+    # ==> (
+    #       ('e', ()),
+    #       ('g', ('e',)),
+    #       ('n', ()),
+    #       ('x', ('n', 'g')),
+    #     )
+    ```
+
+    """
+    # This function additionally depends on:
+    #   self._dist_fn_args
+    #   self._dist_fn_wrapped
+    # TODO(b/129008220): Robustify this procedure. Eg, handle collisions better,
+    # ignore args prefixed with `_`.
+    if distribution_names is None or any(self._dist_fn_args):
+      distribution_names = _resolve_distribution_names(
+          self._dist_fn_args, distribution_names, leaf_name)
+    if len(set(distribution_names)) != len(distribution_names):
+      raise ValueError('Distribution names must be unique: {}'.format(
+          distribution_names))
+    if len(distribution_names) != len(self._dist_fn_wrapped):
+      raise ValueError('Distribution names must be 1:1 with `rvs`.')
+    return tuple(zip(distribution_names,
+                     tuple(() if a is None else a for a in self._dist_fn_args)))
+
+  _mean = _make_summary_statistic('mean')
+  _mode = _make_summary_statistic('mode')
+  _stddev = _make_summary_statistic('stddev')
+  _variance = _make_summary_statistic('variance')
+
+  def _entropy(self):
+    """Shannon entropy in nats."""
+    if any(self._dist_fn_args):
+      raise ValueError(
+          'Can only compute entropy when all distributions are independent.')
+    return sum(joint_distribution_lib.maybe_check_wont_broadcast(
+        (d().entropy() for d in self._dist_fn_wrapped),
+        self.validate_args))
+
+  def _cross_entropy(self, other):
+    if (not isinstance(other, JointDistributionSequential) or
+        len(self.model) != len(other.model)):
+      raise ValueError(
+          'Can only compute cross entropy between `JointDistributionSequential`s '
+          'with the same number of component distributions.')
+    if any(self._dist_fn_args) or any(other._dist_fn_args):  # pylint: disable=protected-access
+      raise ValueError(
+          'Can only compute cross entropy when all component distributions '
+          'are independent.')
+    return sum(joint_distribution_lib.maybe_check_wont_broadcast(
+        (d0().cross_entropy(d1()) for d0, d1
+         in zip(self._dist_fn_wrapped, other._dist_fn_wrapped)),  # pylint: disable=protected-access
+        self.validate_args))
+
+  def __getitem__(self, slices):
+    # There will be some users that who won't like how we've implemented
+    # slicing. The currently implemented policy is to slice "upstream" and let
+    # post sliced distributions propagate forward. While this is efficient it
+    # also means that downstream makers *might* no longer correctly broadcast
+    # with the new inputs.
+    #
+    # For example:
+    #
+    # ```python
+    # d = JointDistributionSequential([
+    #   tfd.Normal(0, scale=[0.5, 1, 1.5]),
+    #   lambda m: tfd.Normal(loc=m, scale=[1, 2, 3]),
+    # ])
+    # d[1:]
+    # # ==> An exception: the following is not possible:
+    # #     Normal(loc=Normal(0, [1, 1.5]).sample(), scale=[1, 2, 3])
+    # #     since shape `[2]` cannot broadcast with shape `[3]`.
+    # ```
+    #
+    # While not supporting this is technically not a bug (its an API decision)
+    # it certainly won't be universally loved. That this is ok follows from the
+    # fact that it will at least fail loudly--unless you slice down so a
+    # dimension now has size `1`--this will broadcast. Here again we argue this
+    # is "ok" because at this level of TFP users are ultimately responsible for
+    # ensuring the correct shapes in their models. Moreover, this problem can
+    # be worked around by using a `Deterministic` node in lieu of any constants.
+    #
+    # Once JointDistributionSequential can be parameterized by a single maker
+    # function, we can choose to support more slicing scenarios by building
+    # every distribution as we would normally then slicing distributions once
+    # built (and passing that as the sole maker to `self.copy`.) Note however
+    # that this would not be as performant as we've currently implemented
+    # things.
+    dfn = []
+    def _sliced_maker(d):
+      def _fn():
+        return d()[slices]
+      return _fn
+    for d, args in zip(self._dist_fn, self._dist_fn_args):
+      if args is None:
+        dfn.append(d[slices])
+      elif args:
+        # Don't slice makers which have inputs; they'll be sliced via upstream.
+        dfn.append(d)
+      else:
+        # Makers which have no deps need slicing, just like distribution
+        # instances.
+        dfn.append(_sliced_maker(d))
+    return self.copy(model=self._unflatten(dfn))
+
+
+def _unify_call_signature(i, dist_fn):
+  """Creates `dist_fn_wrapped` which calls `dist_fn` with all prev nodes.
+
+  Args:
+    i: Python `int` corresponding to position in topologically sorted DAG.
+    dist_fn: Python `callable` which takes a subset of previously constructed
+      distributions (in reverse order) and produces a new distribution instance.
+
+  Returns:
+    dist_fn_wrapped: Python `callable` which takes all previous distributions
+      (in non reverse order) and produces a  new distribution instance.
+    args: `tuple` of `str` representing the arg names of `dist_fn` (and in non
+      wrapped, "natural" order). `None` is returned only if the input is not a
+      `callable`.
+  """
+  if distribution_util.is_distribution_instance(dist_fn):
+    return (lambda *_: dist_fn), None
+
+  if not callable(dist_fn):
+    raise TypeError('{} must be either `tfd.Distribution`-like or '
+                    '`callable`.'.format(dist_fn))
+
+  args = _get_required_args(dist_fn)
+  if not args:
+    return (lambda *_: dist_fn()), ()
+
+  @functools.wraps(dist_fn)
+  def dist_fn_wrapped(*xs):
+    """Calls `dist_fn` with reversed and truncated args."""
+    if i != len(xs):
+      raise ValueError(
+          'Internal Error: Unexpected number of inputs provided to {}-th '
+          'distribution maker (dist_fn: {}, expected: {}, saw: {}).'.format(
+              i, dist_fn, i, len(xs)))
+    if len(xs) < len(args):
+      raise ValueError(
+          'Internal Error: Too few inputs provided to {}-th distribution maker '
+          '(dist_fn: {}, expected: {}, saw: {}).'.format(
+              i, dist_fn, len(args), len(xs)))
+    return dist_fn(*reversed(xs[-len(args):]))
+  return dist_fn_wrapped, args
+
+
+def _resolve_distribution_names(dist_fn_args, dist_names, leaf_name):
+  """Uses arg names to resolve distribution names."""
+  if dist_names is None:
+    dist_names = []
+  else:
+    dist_names = dist_names.copy()
+  n = len(dist_fn_args)
+  dist_names.extend([None]*(n - len(dist_names)))
+  for i_, args in enumerate(reversed(dist_fn_args)):
+    if not args:
+      continue  # There's no args to analyze.
+    i = n - i_ - 1
+    for j, arg_name in enumerate(args):
+      dist_names[i - j - 1] = arg_name
+  j = 0
+  for i_ in range(len(dist_names)):
+    i = n - i_ - 1
+    if dist_names[i] is None:
+      dist_names[i] = leaf_name if j == 0 else leaf_name + str(j)
+      j += 1
+  return tuple(dist_names)
+
+
+def _get_required_args(fn):
+  """Returns the distribution's required args."""
+  argspec = tf_inspect.getfullargspec(fn)
+  args = argspec.args
+  if tf_inspect.isclass(fn):
+    args = args[1:]  # Remove the `self` arg.
+  if argspec.defaults:
+    # Remove the args which have defaults. By convention we only feed
+    # *required args*. This means some distributions must always be wrapped
+    # with a `lambda`, e.g., `lambda logits: tfd.Bernoulli(logits=logits)`
+    # or `lambda probs: tfd.Bernoulli(probs=probs)`.
+    args = args[:-len(argspec.defaults)]
+  return tuple(args)
+
+
+@kullback_leibler.RegisterKL(JointDistributionSequential,
+                             JointDistributionSequential)
+def _kl_joint_joint(d0, d1, name=None):
+  """Calculate the KL divergence between two `JointDistributionSequential`s.
+
+  Args:
+    d0: instance of a `JointDistributionSequential` object.
+    d1: instance of a `JointDistributionSequential` object.
+    name: (optional) Name to use for created operations.
+      Default value: `"kl_joint_joint"`.
+
+  Returns:
+    kl_joint_joint: `Tensor` The sum of KL divergences between elemental
+      distributions of two joint distributions.
+
+  Raises:
+    ValueError: when joint distributions have a different number of elemental
+      distributions.
+    ValueError: when either joint distribution has a distribution with dynamic
+      dependency, i.e., when either joint distribution is not a collection of
+      independent distributions.
+  """
+  if len(d0._dist_fn_wrapped) != len(d1._dist_fn_wrapped):  # pylint: disable=protected-access
+    raise ValueError(
+        'Can only compute KL divergence between when each has the'
+        'same number of component distributions.')
+  if (not all(a is None for a in d0._dist_fn_args) or  # pylint: disable=protected-access
+      not all(a is None for a in d1._dist_fn_args)):  # pylint: disable=protected-access
+    raise ValueError(
+        'Can only compute KL divergence when all distributions are '
+        'independent.')
+  with tf.name_scope(name or 'kl_jointseq_jointseq'):
+    return sum(kullback_leibler.kl_divergence(d0_(), d1_())
+               for d0_, d1_ in zip(d0._dist_fn_wrapped, d1._dist_fn_wrapped))  # pylint: disable=protected-access

--- a/gems/flows/permute.py
+++ b/gems/flows/permute.py
@@ -1,0 +1,163 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Permutation bijectors."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Dependency imports
+import numpy as np
+
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.bijectors import bijector
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import tensorshape_util
+
+
+__all__ = [
+    "Permute",
+]
+
+
+class Permute(bijector.Bijector):
+  """Permutes the rightmost dimension of a `Tensor`.
+
+  ```python
+  reverse = tfp.bijectors.Permute(permutation=[2, 1, 0])
+
+  reverse.forward([-1., 0., 1.])
+  # ==> [1., 0., -1]
+
+  reverse.inverse([1., 0., -1])
+  # ==> [-1., 0., 1.]
+
+  reverse.forward_log_det_jacobian(any_value)
+  # ==> 0.
+
+  reverse.inverse_log_det_jacobian(any_value)
+  # ==> 0.
+  ```
+
+  Warning: `tf.estimator` may repeatedly build the graph thus
+  `Permute(np.random.permutation(event_size)).astype("int32"))` is not a
+  reliable parameterization (nor would it be even if using `tf.constant`). A
+  safe alternative is to use `tf.get_variable` to achieve "init once" behavior,
+  i.e.,
+
+  ```python
+  def init_once(x, name):
+    return tf.get_variable(name, initializer=x, trainable=False)
+
+  Permute(permutation=init_once(
+      np.random.permutation(event_size).astype("int32"),
+      name="permutation"))
+  ```
+
+  """
+
+  def __init__(self, permutation, axis=-1, validate_args=False, name=None):
+    """Creates the `Permute` bijector.
+
+    Args:
+      permutation: An `int`-like vector-shaped `Tensor` representing the
+        permutation to apply to the `axis` dimension of the transformed
+        `Tensor`.
+      axis: Scalar `int` `Tensor` representing the dimension over which to
+        `tf.gather`. `axis` must be relative to the end (reading left to right)
+        thus must be negative.
+        Default value: `-1` (i.e., right-most).
+      validate_args: Python `bool` indicating whether arguments should be
+        checked for correctness.
+      name: Python `str`, name given to ops managed by this object.
+
+    Raises:
+      TypeError: if `not dtype_util.is_integer(permutation.dtype)`.
+      ValueError: if `permutation` does not contain exactly one of each of
+        `{0, 1, ..., d}`.
+      NotImplementedError: if `axis` is not known prior to graph execution.
+      NotImplementedError: if `axis` is not negative.
+    """
+    with tf.name_scope(name or "permute"):
+      axis = tf.convert_to_tensor(value=axis, name="axis")
+      if not dtype_util.is_integer(axis.dtype):
+        raise TypeError("axis.dtype ({}) should be `int`-like.".format(
+            dtype_util.name(axis.dtype)))
+      permutation = tf.convert_to_tensor(value=permutation, name="permutation")
+      if not dtype_util.is_integer(permutation.dtype):
+        raise TypeError("permutation.dtype ({}) should be `int`-like.".format(
+            dtype_util.name(permutation.dtype)))
+      p = tf.get_static_value(permutation)
+      if p is not None:
+        if set(p) != set(np.arange(p.size)):
+          raise ValueError("Permutation over `d` must contain exactly one of "
+                           "each of `{0, 1, ..., d}`.")
+      elif validate_args:
+        p, _ = tf.nn.top_k(
+            -permutation, k=tf.shape(input=permutation)[-1], sorted=True)
+        permutation = distribution_util.with_dependencies([
+            assert_util.assert_equal(
+                -p,
+                tf.range(tf.size(input=p)),
+                message=("Permutation over `d` must contain exactly one of "
+                         "each of `{0, 1, ..., d}`.")),
+        ], permutation)
+      axis_ = tf.get_static_value(axis)
+      if axis_ is None:
+        raise NotImplementedError("`axis` must be known prior to graph "
+                                  "execution.")
+      elif axis_ >= 0:
+        raise NotImplementedError("`axis` must be relative the rightmost "
+                                  "dimension, i.e., negative.")
+      else:
+        forward_min_event_ndims = int(np.abs(axis_))
+      self._permutation = permutation
+      self._axis = axis
+      super(Permute, self).__init__(
+          forward_min_event_ndims=forward_min_event_ndims,
+          is_constant_jacobian=True,
+          validate_args=validate_args,
+          name=name or "permute")
+
+  @property
+  def permutation(self):
+    return self._permutation
+
+  @property
+  def axis(self):
+    return self._axis
+
+  def _forward(self, x, **condition_kwargs):
+    y = tf.gather(x, self.permutation, axis=self.axis)
+    tensorshape_util.set_shape(y, x.shape)
+    return y
+
+  def _inverse(self, y, **condition_kwargs):
+    x = tf.gather(
+        y, tf.math.invert_permutation(self.permutation), axis=self.axis)
+    tensorshape_util.set_shape(x, y.shape)
+    return x
+
+  def _inverse_log_det_jacobian(self, y, **condition_kwargs):
+    # is_constant_jacobian = True for this bijector, hence the
+    # `log_det_jacobian` need only be specified for a single input, as this will
+    # be tiled to match `event_ndims`.
+    return tf.constant(0., dtype=dtype_util.base_dtype(y.dtype))
+
+  def _forward_log_det_jacobian(self, x, **condition_kwargs):
+    return tf.constant(0., dtype=dtype_util.base_dtype(x.dtype))

--- a/gems/flows/real_nvp_custom.py
+++ b/gems/flows/real_nvp_custom.py
@@ -1,0 +1,326 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Real NVP bijector."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+
+from tensorflow_probability.python.bijectors import bijector
+from tensorflow_probability.python.internal import tensorshape_util
+
+
+__all__ = [
+    "RealNVP",
+    "real_nvp_default_template"
+]
+
+
+class RealNVP(bijector.Bijector):
+  """RealNVP "affine coupling layer" for vector-valued events.
+
+  Real NVP models a normalizing flow on a `D`-dimensional distribution via a
+  single `D-d`-dimensional conditional distribution [(Dinh et al., 2017)][1]:
+
+  `y[d:D] = x[d:D] * tf.exp(log_scale_fn(x[0:d])) + shift_fn(x[0:d])`
+  `y[0:d] = x[0:d]`
+
+  The last `D-d` units are scaled and shifted based on the first `d` units only,
+  while the first `d` units are 'masked' and left unchanged. Real NVP's
+  `shift_and_log_scale_fn` computes vector-valued quantities. For
+  scale-and-shift transforms that do not depend on any masked units, i.e.
+  `d=0`, use the `tfb.Affine` bijector with learned parameters instead.
+
+  Masking is currently only supported for base distributions with
+  `event_ndims=1`. For more sophisticated masking schemes like checkerboard or
+  channel-wise masking [(Papamakarios et al., 2016)[4], use the `tfb.Permute`
+  bijector to re-order desired masked units into the first `d` units. For base
+  distributions with `event_ndims > 1`, use the `tfb.Reshape` bijector to
+  flatten the event shape.
+
+  Recall that the MAF bijector [(Papamakarios et al., 2016)][4] implements a
+  normalizing flow via an autoregressive transformation. MAF and IAF have
+  opposite computational tradeoffs - MAF can train all units in parallel but
+  must sample units sequentially, while IAF must train units sequentially but
+  can sample in parallel. In contrast, Real NVP can compute both forward and
+  inverse computations in parallel. However, the lack of an autoregressive
+  transformations makes it less expressive on a per-bijector basis.
+
+  A "valid" `shift_and_log_scale_fn` must compute each `shift` (aka `loc` or
+  "mu" in [Papamakarios et al. (2016)][4]) and `log(scale)` (aka "alpha" in
+  [Papamakarios et al. (2016)][4]) such that each are broadcastable with the
+  arguments to `forward` and `inverse`, i.e., such that the calculations in
+  `forward`, `inverse` [below] are possible. For convenience,
+  `real_nvp_default_nvp` is offered as a possible `shift_and_log_scale_fn`
+  function.
+
+  NICE [(Dinh et al., 2014)][2] is a special case of the Real NVP bijector
+  which discards the scale transformation, resulting in a constant-time
+  inverse-log-determinant-Jacobian. To use a NICE bijector instead of Real
+  NVP, `shift_and_log_scale_fn` should return `(shift, None)`, and
+  `is_constant_jacobian` should be set to `True` in the `RealNVP` constructor.
+  Calling `real_nvp_default_template` with `shift_only=True` returns one such
+  NICE-compatible `shift_and_log_scale_fn`.
+
+  Caching: the scalar input depth `D` of the base distribution is not known at
+  construction time. The first call to any of `forward(x)`, `inverse(x)`,
+  `inverse_log_det_jacobian(x)`, or `forward_log_det_jacobian(x)` memoizes
+  `D`, which is re-used in subsequent calls. This shape must be known prior to
+  graph execution (which is the case if using tf.layers).
+
+  #### Example Use
+
+  ```python
+  tfd = tfp.distributions
+  tfb = tfp.bijectors
+
+  # A common choice for a normalizing flow is to use a Gaussian for the base
+  # distribution. (However, any continuous distribution would work.) E.g.,
+  nvp = tfd.TransformedDistribution(
+      distribution=tfd.MultivariateNormalDiag(loc=[0., 0., 0.]),
+      bijector=tfb.RealNVP(
+          num_masked=2,
+          shift_and_log_scale_fn=tfb.real_nvp_default_template(
+              hidden_layers=[512, 512])))
+
+  x = nvp.sample()
+  nvp.log_prob(x)
+  nvp.log_prob(0.)
+  ```
+
+  For more examples, see [Jang (2018)][3].
+
+  #### References
+
+  [1]: Laurent Dinh, Jascha Sohl-Dickstein, and Samy Bengio. Density Estimation
+       using Real NVP. In _International Conference on Learning
+       Representations_, 2017. https://arxiv.org/abs/1605.08803
+
+  [2]: Laurent Dinh, David Krueger, and Yoshua Bengio. NICE: Non-linear
+       Independent Components Estimation. _arXiv preprint arXiv:1410.8516_,
+       2014. https://arxiv.org/abs/1410.8516
+
+  [3]: Eric Jang. Normalizing Flows Tutorial, Part 2: Modern Normalizing Flows.
+       _Technical Report_, 2018. http://blog.evjang.com/2018/01/nf2.html
+
+  [4]: George Papamakarios, Theo Pavlakou, and Iain Murray. Masked
+       Autoregressive Flow for Density Estimation. In _Neural Information
+       Processing Systems_, 2017. https://arxiv.org/abs/1705.07057
+  """
+
+  def __init__(self,
+               num_masked,
+               shift_and_log_scale_fn,
+               is_constant_jacobian=False,
+               validate_args=False,
+               name=None):
+    """Creates the Real NVP or NICE bijector.
+
+    Args:
+      num_masked: Python `int` indicating that the first `d` units of the event
+        should be masked. Must be in the closed interval `[1, D-1]`, where `D`
+        is the event size of the base distribution.
+      shift_and_log_scale_fn: Python `callable` which computes `shift` and
+        `log_scale` from both the forward domain (`x`) and the inverse domain
+        (`y`). Calculation must respect the "autoregressive property" (see class
+        docstring). Suggested default
+        `masked_autoregressive_default_template(hidden_layers=...)`.
+        Typically the function contains `tf.Variables` and is wrapped using
+        `tf.make_template`. Returning `None` for either (both) `shift`,
+        `log_scale` is equivalent to (but more efficient than) returning zero.
+      is_constant_jacobian: Python `bool`. Default: `False`. When `True` the
+        implementation assumes `log_scale` does not depend on the forward domain
+        (`x`) or inverse domain (`y`) values. (No validation is made;
+        `is_constant_jacobian=False` is always safe but possibly computationally
+        inefficient.)
+      validate_args: Python `bool` indicating whether arguments should be
+        checked for correctness.
+      name: Python `str`, name given to ops managed by this object.
+
+    Raises:
+      ValueError: If num_masked < 1.
+    """
+    name = name or "real_nvp"
+    if num_masked <= 0:
+      raise ValueError("num_masked must be a positive integer.")
+    self._num_masked = num_masked
+    # At construction time, we don't know input_depth.
+    self._input_depth = None
+    self._shift_and_log_scale_fn = shift_and_log_scale_fn
+    super(RealNVP, self).__init__(
+        forward_min_event_ndims=1,
+        is_constant_jacobian=is_constant_jacobian,
+        validate_args=validate_args,
+        name=name)
+
+  def _cache_input_depth(self, x):
+    if self._input_depth is None:
+      self._input_depth = tf.compat.dimension_value(
+          tensorshape_util.with_rank_at_least(x.shape, 1)[-1])
+      if self._input_depth is None:
+        raise NotImplementedError(
+            "Rightmost dimension must be known prior to graph execution.")
+      if self._num_masked >= self._input_depth:
+        raise ValueError(
+            "Number of masked units must be smaller than the event size.")
+
+  def _forward(self, x, **condition_kwargs):
+    self._cache_input_depth(x)
+    # Performs scale and shift.
+    x0, x1 = x[..., :self._num_masked], x[..., self._num_masked:]
+    shift, log_scale = self._shift_and_log_scale_fn(
+        x0, self._input_depth - self._num_masked, **condition_kwargs)
+    y1 = x1
+    if log_scale is not None:
+      y1 *= tf.exp(log_scale)
+    if shift is not None:
+      y1 += shift
+    y = tf.concat([x0, y1], axis=-1)
+    return y
+
+  def _inverse(self, y, **condition_kwargs):
+    self._cache_input_depth(y)
+    # Performs un-shift and un-scale.
+    y0, y1 = y[..., :self._num_masked], y[..., self._num_masked:]
+    shift, log_scale = self._shift_and_log_scale_fn(
+        y0, self._input_depth - self._num_masked, **condition_kwargs)
+    x1 = y1
+    if shift is not None:
+      x1 -= shift
+    if log_scale is not None:
+      x1 *= tf.exp(-log_scale)
+    x = tf.concat([y0, x1], axis=-1)
+    return x
+
+  def _inverse_log_det_jacobian(self, y, **condition_kwargs):
+    self._cache_input_depth(y)
+    y0 = y[..., :self._num_masked]
+    _, log_scale = self._shift_and_log_scale_fn(
+        y0, self._input_depth - self._num_masked, **condition_kwargs)
+    if log_scale is None:
+      return tf.constant(0., dtype=y.dtype, name="ildj")
+    return -tf.reduce_sum(input_tensor=log_scale, axis=-1)
+
+  def _forward_log_det_jacobian(self, x, **condition_kwargs):
+    self._cache_input_depth(x)
+    x0 = x[..., :self._num_masked]
+    _, log_scale = self._shift_and_log_scale_fn(
+        x0, self._input_depth - self._num_masked, **condition_kwargs)
+    if log_scale is None:
+      return tf.constant(0., dtype=x.dtype, name="fldj")
+    return tf.reduce_sum(input_tensor=log_scale, axis=-1)
+
+
+def real_nvp_default_template(hidden_layers,
+                              shift_only=False,
+                              activation=tf.nn.relu,
+                              name=None,
+                              *args,  # pylint: disable=keyword-arg-before-vararg
+                              **kwargs):
+  """Build a scale-and-shift function using a multi-layer neural network.
+
+  This will be wrapped in a make_template to ensure the variables are only
+  created once. It takes the `d`-dimensional input x[0:d] and returns the `D-d`
+  dimensional outputs `loc` ("mu") and `log_scale` ("alpha").
+
+  The default template does not support conditioning and will raise an
+  exception if `condition_kwargs` are passed to it. To use conditioning in
+  real nvp bijector, implement a conditioned shift/scale template that
+  handles the `condition_kwargs`.
+
+  Arguments:
+    hidden_layers: Python `list`-like of non-negative integer, scalars
+      indicating the number of units in each hidden layer. Default: `[512, 512].
+    shift_only: Python `bool` indicating if only the `shift` term shall be
+      computed (i.e. NICE bijector). Default: `False`.
+    activation: Activation function (callable). Explicitly setting to `None`
+      implies a linear activation.
+    name: A name for ops managed by this function. Default:
+      "real_nvp_default_template".
+    *args: `tf.layers.dense` arguments.
+    **kwargs: `tf.layers.dense` keyword arguments.
+
+  Returns:
+    shift: `Float`-like `Tensor` of shift terms ("mu" in
+      [Papamakarios et al.  (2016)][1]).
+    log_scale: `Float`-like `Tensor` of log(scale) terms ("alpha" in
+      [Papamakarios et al. (2016)][1]).
+
+  Raises:
+    NotImplementedError: if rightmost dimension of `inputs` is unknown prior to
+      graph execution, or if `condition_kwargs` is not empty.
+
+  #### References
+
+  [1]: George Papamakarios, Theo Pavlakou, and Iain Murray. Masked
+       Autoregressive Flow for Density Estimation. In _Neural Information
+       Processing Systems_, 2017. https://arxiv.org/abs/1705.07057
+  """
+
+  with tf.compat.v2.name_scope(name or "real_nvp_default_template"):
+
+    def _fn(x, output_units, **condition_kwargs):
+      """Fully connected MLP parameterized via `real_nvp_template`."""
+      if condition_kwargs:
+        raise NotImplementedError(
+            'Conditioning not implemented in the default template.')
+
+      print('x.shape', x.shape)
+
+      if tensorshape_util.rank(x.shape) == 2:
+        x = x[tf.newaxis, ...]
+        # reshape_output = lambda x: x[:,0]
+        raise ValueError(
+          'batch_size must be specified in `nvp.sample(batch_size)`')
+      else:
+        reshape_output = lambda x: x
+      
+      batch_size = x.shape[0]
+      N_objects = x.shape[1]
+      
+      # here we want a NN per batch dimension
+      shifts = tf.zeros([batch_size, 1, output_units])
+      log_scales = tf.zeros([batch_size, 1, output_units])
+
+      # shift and scales will be applied on the output_units dims
+      for i in range(N_objects):
+        x_ = x[:, i, ...]
+        
+        for units in hidden_layers:
+          x_ = tf.compat.v1.layers.dense(
+              inputs=x_,
+              units=units,
+              activation=activation,
+              *args,  # pylint: disable=keyword-arg-before-vararg
+              **kwargs)
+        x_ = tf.compat.v1.layers.dense(
+            inputs=x_,
+            units=(1 if shift_only else 2) * output_units,
+            activation=None,
+            *args,  # pylint: disable=keyword-arg-before-vararg
+            **kwargs)
+        if shift_only:
+          return reshape_output(x), None
+        
+        shift, log_scale = tf.split(x_, 2, axis=-1)
+        
+        shifts = tf.concat([shifts, shift[:,tf.newaxis,:]], axis=1)
+        log_scales = tf.concat([log_scales, log_scale[:,tf.newaxis,:]], axis=1)
+      
+      return shifts[:, 1:, :], log_scales[:, 1:, :]
+
+    return tf.compat.v1.make_template("real_nvp_default_template", _fn)

--- a/gems/flows/real_nvp_custom.py
+++ b/gems/flows/real_nvp_custom.py
@@ -274,15 +274,13 @@ def real_nvp_default_template(hidden_layers,
   """
 
   with tf.compat.v2.name_scope(name or "real_nvp_default_template"):
-
+    print(name)
     def _fn(x, output_units, **condition_kwargs):
       """Fully connected MLP parameterized via `real_nvp_template`.
       x is the sample from the distribution [batch_size, N_objects, d]
       y is the cosmic shear used to condition the realNVP [batch_size, 2]
       """
       # print(condition_kwargs)
-      if condition_kwargs:
-        y = condition_kwargs['condition']
         # print(y)
         # raise NotImplementedError(
         #     'Conditioning not implemented in the default template.')
@@ -292,8 +290,11 @@ def real_nvp_default_template(hidden_layers,
       if tensorshape_util.rank(x.shape) == 2:
         x = x[tf.newaxis, ...]
         # reshape_output = lambda x: x[:,0]
-        raise ValueError(
-          'batch_size must be specified in `nvp.sample(batch_size)`')
+        # raise ValueError(
+        #   'batch_size must be specified in `nvp.sample(batch_size)`')
+        # tf.expand_dims()
+        x = x[tf.newaxis, ...]
+        reshape_output = lambda x: x
       else:
         reshape_output = lambda x: x
       
@@ -302,6 +303,14 @@ def real_nvp_default_template(hidden_layers,
       N_objects = x.shape[1]
       d = x.shape[2]
       
+      if condition_kwargs:
+        # print(condition_kwargs['condition'])
+        # print(condition_kwargs.keys())
+        # print(condition_kwargs.values())
+        y = condition_kwargs['condition']
+      else:
+        y = tf.zeros([batch_size, 2])
+
       y = tf.reshape(y, [batch_size, 2])
 
       # here we want a NN per batch dimension

--- a/gems/flows/real_nvp_custom.py
+++ b/gems/flows/real_nvp_custom.py
@@ -274,7 +274,7 @@ def real_nvp_default_template(hidden_layers,
   """
 
   with tf.compat.v2.name_scope(name or "real_nvp_default_template"):
-    print(name)
+    #print(name)
     def _fn(x, output_units, **condition_kwargs):
       """Fully connected MLP parameterized via `real_nvp_template`.
       x is the sample from the distribution [batch_size, N_objects, d]
@@ -316,7 +316,7 @@ def real_nvp_default_template(hidden_layers,
       # here we want a NN per batch dimension
       shifts = tf.zeros([batch_size, 1, output_units])
       log_scales = tf.zeros([batch_size, 1, output_units])
-
+    
       # shift and scales will be applied on the output_units dims
       for i in range(N_objects):
         x_ = x[:, i, ...]

--- a/gems/flows/real_nvp_custom.py
+++ b/gems/flows/real_nvp_custom.py
@@ -287,7 +287,7 @@ def real_nvp_default_template(hidden_layers,
 
       # print('x.shape', x.shape)
 
-      if tensorshape_util.rank(x.shape) == 2:
+      if tensorshape_util.rank(x.shape) == 1:
         x = x[tf.newaxis, ...]
         # reshape_output = lambda x: x[:,0]
         # raise ValueError(
@@ -300,8 +300,8 @@ def real_nvp_default_template(hidden_layers,
       
 
       batch_size = x.shape[0]
-      N_objects = x.shape[1]
-      d = x.shape[2]
+      #N_objects = x.shape[1]
+      d = x.shape[1]
       
       if condition_kwargs:
         # print(condition_kwargs['condition'])
@@ -314,35 +314,36 @@ def real_nvp_default_template(hidden_layers,
       y = tf.reshape(y, [batch_size, 2])
 
       # here we want a NN per batch dimension
-      shifts = tf.zeros([batch_size, 1, output_units])
-      log_scales = tf.zeros([batch_size, 1, output_units])
+      #shifts = tf.zeros([batch_size, output_units])
+      #log_scales = tf.zeros([batch_size, output_units])
     
       # shift and scales will be applied on the output_units dims
-      for i in range(N_objects):
-        x_ = x[:, i, ...]
-        x_ = tf.concat([x_, y], axis=-1)
+      #for i in range(N_objects):
+      x_ = x[:, ...]
+      x_ = tf.concat([x_, y], axis=-1)
 
-        for units in hidden_layers:
-          x_ = tf.compat.v1.layers.dense(
+      for units in hidden_layers:
+        x_ = tf.compat.v1.layers.dense(
               inputs=x_,
               units=units,
               activation=activation,
               *args,  # pylint: disable=keyword-arg-before-vararg
               **kwargs)
-        x_ = tf.compat.v1.layers.dense(
+      x_ = tf.compat.v1.layers.dense(
             inputs=x_,
             units=(1 if shift_only else 2) * output_units,
             activation=None,
             *args,  # pylint: disable=keyword-arg-before-vararg
             **kwargs)
-        if shift_only:
-          return reshape_output(x), None
-        
-        shift, log_scale = tf.split(x_, 2, axis=-1)
-        
-        shifts = tf.concat([shifts, shift[:,tf.newaxis,:]], axis=1)
-        log_scales = tf.concat([log_scales, log_scale[:,tf.newaxis,:]], axis=1)
+      if shift_only:
+        return reshape_output(x), None
+
+      shift, log_scale = tf.split(x_, 2, axis=-1)
+
+      #shifts = tf.concat([shifts, shift[:,:]], axis=1)
+      #log_scales = tf.concat([log_scales, log_scale[:,:]], axis=1)
+      return shift, log_scale
       
-      return shifts[:, 1:, :], log_scales[:, 1:, :]
+      #return shifts[:, :], log_scales[:, :]
 
     return tf.compat.v1.make_template("real_nvp_default_template", _fn)

--- a/gems/flows/sigmoid.py
+++ b/gems/flows/sigmoid.py
@@ -1,0 +1,101 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Sigmoid bijector."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+from tensorflow_probability.python.bijectors import bijector
+
+
+__all__ = [
+    "Sigmoid",
+]
+
+
+class Sigmoid(bijector.Bijector):
+  """Bijector which computes `Y = g(X) = 1 / (1 + exp(-X))`."""
+
+  def __init__(self, validate_args=False, name="sigmoid"):
+    super(Sigmoid, self).__init__(
+        forward_min_event_ndims=0,
+        validate_args=validate_args,
+        name=name)
+
+  def _forward(self, x, **condition_kwargs):
+    return tf.sigmoid(x)
+
+  def _inverse(self, y, **condition_kwargs):
+    return tf.math.log(y) - tf.math.log1p(-y)
+
+  # We implicitly rely on _forward_log_det_jacobian rather than explicitly
+  # implement _inverse_log_det_jacobian since directly using
+  # `-tf.log(y) - tf.log1p(-y)` has lower numerical precision.
+
+  def _forward_log_det_jacobian(self, x, **condition_kwargs):
+    return -tf.nn.softplus(-x) - tf.nn.softplus(x)
+  
+
+class Scale(bijector.Bijector):
+
+    def __init__(self, scale, validate_args=False, name='scale'):
+      self.scale = scale
+      super(Scale, self).__init__(
+          validate_args=validate_args,
+          forward_min_event_ndims=0,
+          name=name)
+
+    def _forward(self, x, **condition_kwargs):
+      return x * self.scale
+
+    def _inverse(self, y, **condition_kwargs):
+      return y / self.scale
+
+    def _inverse_log_det_jacobian(self, y, **condition_kwargs):
+      return -self._forward_log_det_jacobian(self._inverse(y))
+
+    def _forward_log_det_jacobian(self, x, **condition_kwargs):
+      # Notice that we needn't do any reducing, even when`event_ndims > 0`.
+      # The base Bijector class will handle reducing for us; it knows how
+      # to do so because we called `super` `__init__` with
+      # `forward_min_event_ndims = 0`.
+      return x
+    
+class Shift(bijector.Bijector):
+
+    def __init__(self, shift, validate_args=False, name='shift'):
+      self.shift = shift
+      super(Shift, self).__init__(
+          validate_args=validate_args,
+          forward_min_event_ndims=0,
+          name=name)
+
+    def _forward(self, x, **condition_kwargs):
+      return x + self.shift
+
+    def _inverse(self, y, **condition_kwargs):
+      return y - self.shift
+
+    def _inverse_log_det_jacobian(self, y, **condition_kwargs):
+      return -self._forward_log_det_jacobian(self._inverse(y))
+
+    def _forward_log_det_jacobian(self, x, **condition_kwargs):
+      # Notice that we needn't do any reducing, even when`event_ndims > 0`.
+      # The base Bijector class will handle reducing for us; it knows how
+      # to do so because we called `super` `__init__` with
+      # `forward_min_event_ndims = 0`.
+      return x

--- a/gems/flows/transformed_distribution.py
+++ b/gems/flows/transformed_distribution.py
@@ -367,13 +367,16 @@ class TransformedDistribution(distribution_lib.Distribution):
     # the result of `self.bijector.forward` is not modified (and thus caching
     # works).
     with self._name_scope(name):
+      print('sample_shape', sample_shape)
       sample_shape = tf.convert_to_tensor(
           value=sample_shape, dtype=tf.int32, name="sample_shape")
       sample_shape, n = self._expand_sample_shape_to_vector(
           sample_shape, "sample_shape")
 
       distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
-      bijector_kwargs["condition"] = kwargs["condition"]
+      # print(distribution_kwargs, bijector_kwargs)
+      # print(bijector_kwargs["condition"])
+      # bijector_kwargs["condition"] = kwargs["condition"]
       # First, generate samples. We will possibly generate extra samples in the
       # event that we need to reinterpret the samples as part of the
       # event_shape.
@@ -389,6 +392,7 @@ class TransformedDistribution(distribution_lib.Distribution):
       # work, it is imperative that this is the last modification to the
       # returned result.
       # print(bijector_kwargs)
+      print('into transform_distribution', x.shape)
       y = self.bijector.forward(x, **bijector_kwargs)
       y = self._set_sample_static_shape(y, sample_shape)
 
@@ -396,7 +400,7 @@ class TransformedDistribution(distribution_lib.Distribution):
 
   def _log_prob(self, y, **kwargs):
     distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
-    bijector_kwargs["condition"] = kwargs["condition"]
+    # bijector_kwargs["condition"] = kwargs["condition"]
     # For caching to work, it is imperative that the bijector is the first to
     # modify the input.
     x = self.bijector.inverse(y, **bijector_kwargs)
@@ -548,6 +552,7 @@ class TransformedDistribution(distribution_lib.Distribution):
            self.event_shape_tensor()], 0)
       x = tf.broadcast_to(x, new_shape)
 
+    print(x.shape)
     y = self.bijector.forward(x, **bijector_kwargs)
 
     sample_shape = tf.convert_to_tensor(

--- a/gems/flows/transformed_distribution.py
+++ b/gems/flows/transformed_distribution.py
@@ -367,7 +367,7 @@ class TransformedDistribution(distribution_lib.Distribution):
     # the result of `self.bijector.forward` is not modified (and thus caching
     # works).
     with self._name_scope(name):
-      print('sample_shape', sample_shape)
+      #print('sample_shape', sample_shape)
       sample_shape = tf.convert_to_tensor(
           value=sample_shape, dtype=tf.int32, name="sample_shape")
       sample_shape, n = self._expand_sample_shape_to_vector(
@@ -392,7 +392,7 @@ class TransformedDistribution(distribution_lib.Distribution):
       # work, it is imperative that this is the last modification to the
       # returned result.
       # print(bijector_kwargs)
-      print('into transform_distribution', x.shape)
+      #print('into transform_distribution', x.shape)
       y = self.bijector.forward(x, **bijector_kwargs)
       y = self._set_sample_static_shape(y, sample_shape)
 

--- a/gems/flows/transformed_distribution.py
+++ b/gems/flows/transformed_distribution.py
@@ -1,0 +1,693 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""A Transformed Distribution class."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow.compat.v1 as tf1
+import tensorflow.compat.v2 as tf
+
+from tensorflow_probability.python.distributions import distribution as distribution_lib
+from tensorflow_probability.python.internal import assert_util
+from tensorflow_probability.python.internal import distribution_util
+from tensorflow_probability.python.internal import dtype_util
+from tensorflow_probability.python.internal import prefer_static
+from tensorflow_probability.python.internal import tensorshape_util
+from tensorflow.python.util import deprecation  # pylint: disable=g-direct-tensorflow-import
+
+__all__ = [
+    "ConditionalTransformedDistribution",
+    "TransformedDistribution",
+]
+
+
+# The following helper functions attempt to statically perform a TF operation.
+# These functions make debugging easier since we can do more validation during
+# graph construction.
+
+
+def _pick_scalar_condition(pred, cond_true, cond_false):
+  """Convenience function which chooses the condition based on the predicate."""
+  # Note: This function is only valid if all of pred, cond_true, and cond_false
+  # are scalars. This means its semantics are arguably more like tf.cond than
+  # tf.where even though we use tf1.where to implement it.
+  pred_ = tf.get_static_value(tf.convert_to_tensor(value=pred))
+  if pred_ is None:
+    return tf1.where(pred, cond_true, cond_false)
+  return cond_true if pred_ else cond_false
+
+
+def _is_scalar_from_shape_tensor(shape):
+  """Returns `True` `Tensor` if `Tensor` shape implies a scalar."""
+  return prefer_static.equal(prefer_static.rank_from_shape(shape), 0)
+
+
+def _default_kwargs_split_fn(kwargs):
+  """Default `kwargs` `dict` getter."""
+  return (kwargs.get("distribution_kwargs", {}),
+          kwargs.get("bijector_kwargs", {}))
+
+
+class TransformedDistribution(distribution_lib.Distribution):
+  """A Transformed Distribution.
+
+  A `TransformedDistribution` models `p(y)` given a base distribution `p(x)`,
+  and a deterministic, invertible, differentiable transform, `Y = g(X)`. The
+  transform is typically an instance of the `Bijector` class and the base
+  distribution is typically an instance of the `Distribution` class.
+
+  A `Bijector` is expected to implement the following functions:
+  - `forward`,
+  - `inverse`,
+  - `inverse_log_det_jacobian`.
+  The semantics of these functions are outlined in the `Bijector` documentation.
+
+  We now describe how a `TransformedDistribution` alters the input/outputs of a
+  `Distribution` associated with a random variable (rv) `X`.
+
+  Write `cdf(Y=y)` for an absolutely continuous cumulative distribution function
+  of random variable `Y`; write the probability density function
+  `pdf(Y=y) := d^k / (dy_1,...,dy_k) cdf(Y=y)` for its derivative wrt to `Y`
+  evaluated at `y`. Assume that `Y = g(X)` where `g` is a deterministic
+  diffeomorphism, i.e., a non-random, continuous, differentiable, and invertible
+  function.  Write the inverse of `g` as `X = g^{-1}(Y)` and `(J o g)(x)` for
+  the Jacobian of `g` evaluated at `x`.
+
+  A `TransformedDistribution` implements the following operations:
+
+    * `sample`
+      Mathematically:   `Y = g(X)`
+      Programmatically: `bijector.forward(distribution.sample(...))`
+
+    * `log_prob`
+      Mathematically:   `(log o pdf)(Y=y) = (log o pdf o g^{-1})(y)
+                         + (log o abs o det o J o g^{-1})(y)`
+      Programmatically: `(distribution.log_prob(bijector.inverse(y))
+                         + bijector.inverse_log_det_jacobian(y))`
+
+    * `log_cdf`
+      Mathematically:   `(log o cdf)(Y=y) = (log o cdf o g^{-1})(y)`
+      Programmatically: `distribution.log_cdf(bijector.inverse(x))`
+
+    * and similarly for: `cdf`, `prob`, `log_survival_function`,
+     `survival_function`.
+
+  A simple example constructing a Log-Normal distribution from a Normal
+  distribution:
+
+  ```python
+  ds = tfp.distributions
+  log_normal = ds.TransformedDistribution(
+    distribution=ds.Normal(loc=0., scale=1.),
+    bijector=ds.bijectors.Exp(),
+    name="LogNormalTransformedDistribution")
+  ```
+
+  A `LogNormal` made from callables:
+
+  ```python
+  ds = tfp.distributions
+  log_normal = ds.TransformedDistribution(
+    distribution=ds.Normal(loc=0., scale=1.),
+    bijector=ds.bijectors.Inline(
+      forward_fn=tf.exp,
+      inverse_fn=tf.log,
+      inverse_log_det_jacobian_fn=(
+        lambda y: -tf.reduce_sum(tf.log(y), axis=-1)),
+    name="LogNormalTransformedDistribution")
+  ```
+
+  Another example constructing a Normal from a StandardNormal:
+
+  ```python
+  ds = tfp.distributions
+  normal = ds.TransformedDistribution(
+    distribution=ds.Normal(loc=0., scale=1.),
+    bijector=ds.bijectors.Affine(
+      shift=-1.,
+      scale_identity_multiplier=2.)
+    name="NormalTransformedDistribution")
+  ```
+
+  A `TransformedDistribution`'s batch- and event-shape are implied by the base
+  distribution unless explicitly overridden by `batch_shape` or `event_shape`
+  arguments. Specifying an overriding `batch_shape` (`event_shape`) is
+  permitted only if the base distribution has scalar batch-shape (event-shape).
+  The bijector is applied to the distribution as if the distribution possessed
+  the overridden shape(s). The following example demonstrates how to construct a
+  multivariate Normal as a `TransformedDistribution`.
+
+  ```python
+  ds = tfp.distributions
+  # We will create two MVNs with batch_shape = event_shape = 2.
+  mean = [[-1., 0],      # batch:0
+          [0., 1]]       # batch:1
+  chol_cov = [[[1., 0],
+               [0, 1]],  # batch:0
+              [[1, 0],
+               [2, 2]]]  # batch:1
+  mvn1 = ds.TransformedDistribution(
+      distribution=ds.Normal(loc=0., scale=1.),
+      bijector=ds.bijectors.Affine(shift=mean, scale_tril=chol_cov),
+      batch_shape=[2],  # Valid because base_distribution.batch_shape == [].
+      event_shape=[2])  # Valid because base_distribution.event_shape == [].
+  mvn2 = ds.MultivariateNormalTriL(loc=mean, scale_tril=chol_cov)
+  # mvn1.log_prob(x) == mvn2.log_prob(x)
+  ```
+
+  """
+
+  def __init__(self,
+               distribution,
+               bijector,
+               batch_shape=None,
+               event_shape=None,
+               kwargs_split_fn=_default_kwargs_split_fn,
+               validate_args=False,
+               parameters=None,
+               name=None):
+    """Construct a Transformed Distribution.
+
+    Args:
+      distribution: The base distribution instance to transform. Typically an
+        instance of `Distribution`.
+      bijector: The object responsible for calculating the transformation.
+        Typically an instance of `Bijector`.
+      batch_shape: `integer` vector `Tensor` which overrides `distribution`
+        `batch_shape`; valid only if `distribution.is_scalar_batch()`.
+      event_shape: `integer` vector `Tensor` which overrides `distribution`
+        `event_shape`; valid only if `distribution.is_scalar_event()`.
+      kwargs_split_fn: Python `callable` which takes a kwargs `dict` and returns
+        a tuple of kwargs `dict`s for each of the `distribution` and `bijector`
+        parameters respectively.
+        Default value: `_default_kwargs_split_fn` (i.e.,
+            `lambda kwargs: (kwargs.get('distribution_kwargs', {}),
+                             kwargs.get('bijector_kwargs', {}))`)
+      validate_args: Python `bool`, default `False`. When `True` distribution
+        parameters are checked for validity despite possibly degrading runtime
+        performance. When `False` invalid inputs may silently render incorrect
+        outputs.
+      parameters: Locals dict captured by subclass constructor, to be used for
+        copy/slice re-instantiation operations.
+      name: Python `str` name prefixed to Ops created by this class. Default:
+        `bijector.name + distribution.name`.
+    """
+    parameters = dict(locals()) if parameters is None else parameters
+    name = name or (("" if bijector is None else bijector.name) +
+                    (distribution.name or ""))
+    with tf.name_scope(name) as name:
+      self._kwargs_split_fn = (_default_kwargs_split_fn
+                               if kwargs_split_fn is None
+                               else kwargs_split_fn)
+      # For convenience we define some handy constants.
+      self._zero = tf.constant(0, dtype=tf.int32, name="zero")
+      self._empty = tf.constant([], dtype=tf.int32, name="empty")
+
+      # We will keep track of a static and dynamic version of
+      # self._is_{batch,event}_override. This way we can do more prior to graph
+      # execution, including possibly raising Python exceptions.
+
+      self._override_batch_shape = self._maybe_validate_shape_override(
+          batch_shape, distribution.is_scalar_batch(), validate_args,
+          "batch_shape")
+      self._is_batch_override = prefer_static.logical_not(
+          prefer_static.equal(
+              prefer_static.rank_from_shape(self._override_batch_shape),
+              self._zero))
+      self._is_maybe_batch_override = bool(
+          tf.get_static_value(self._override_batch_shape) is None or
+          tf.get_static_value(self._override_batch_shape).size != 0)
+
+      self._override_event_shape = self._maybe_validate_shape_override(
+          event_shape, distribution.is_scalar_event(), validate_args,
+          "event_shape")
+      self._is_event_override = prefer_static.logical_not(
+          prefer_static.equal(
+              prefer_static.rank_from_shape(self._override_event_shape),
+              self._zero))
+      self._is_maybe_event_override = bool(
+          tf.get_static_value(self._override_event_shape) is None or
+          tf.get_static_value(self._override_event_shape).size != 0)
+
+      # To convert a scalar distribution into a multivariate distribution we
+      # will draw dims from the sample dims, which are otherwise iid. This is
+      # easy to do except in the case that the base distribution has batch dims
+      # and we're overriding event shape. When that case happens the event dims
+      # will incorrectly be to the left of the batch dims. In this case we'll
+      # cyclically permute left the new dims.
+      self._needs_rotation = prefer_static.reduce_all([
+          self._is_event_override,
+          prefer_static.logical_not(self._is_batch_override),
+          prefer_static.logical_not(distribution.is_scalar_batch())])
+      override_event_ndims = prefer_static.rank_from_shape(
+          self._override_event_shape)
+      self._rotate_ndims = _pick_scalar_condition(
+          self._needs_rotation, override_event_ndims, 0)
+      # We'll be reducing the head dims (if at all), i.e., this will be []
+      # if we don't need to reduce.
+      self._reduce_event_indices = tf.range(
+          self._rotate_ndims - override_event_ndims, self._rotate_ndims)
+
+    self._distribution = distribution
+    self._bijector = bijector
+    super(TransformedDistribution, self).__init__(
+        dtype=self._distribution.dtype,
+        reparameterization_type=self._distribution.reparameterization_type,
+        validate_args=validate_args,
+        allow_nan_stats=self._distribution.allow_nan_stats,
+        parameters=parameters,
+        # We let TransformedDistribution access _graph_parents since this class
+        # is more like a baseclass than derived.
+        graph_parents=(distribution._graph_parents +  # pylint: disable=protected-access
+                       bijector.graph_parents),
+        name=name)
+
+  @property
+  def distribution(self):
+    """Base distribution, p(x)."""
+    return self._distribution
+
+  @property
+  def bijector(self):
+    """Function transforming x => y."""
+    return self._bijector
+
+  def __getitem__(self, slices):
+    # Because slicing is parameterization-dependent, we only implement slicing
+    # for instances of TD, not subclasses thereof.
+    if type(self) is not TransformedDistribution:  # pylint: disable=unidiomatic-typecheck
+      return super(TransformedDistribution, self).__getitem__(slices)
+
+    if tensorshape_util.rank(self.distribution.batch_shape) is None:
+      raise NotImplementedError(
+          "Slicing TransformedDistribution with underlying distribution of "
+          "unknown rank is not yet implemented")
+    overrides = {}
+    if (tensorshape_util.rank(self.distribution.batch_shape) == 0 and
+        self.parameters.get("batch_shape", None) is not None):
+      overrides["batch_shape"] = tf.shape(
+          input=tf.zeros(self.parameters["batch_shape"])[slices])
+    elif self.parameters.get("distribution", None) is not None:
+      overrides["distribution"] = self.distribution[slices]
+    return self.copy(**overrides)
+
+  def _event_shape_tensor(self):
+    return self.bijector.forward_event_shape_tensor(
+        distribution_util.pick_vector(
+            self._is_event_override,
+            self._override_event_shape,
+            self.distribution.event_shape_tensor()))
+
+  def _event_shape(self):
+    # If there's a chance that the event_shape has been overridden, we return
+    # what we statically know about the `event_shape_override`. This works
+    # because: `_is_maybe_event_override` means `static_override` is `None` or a
+    # non-empty list, i.e., we don't statically know the `event_shape` or we do.
+    #
+    # Since the `bijector` may change the `event_shape`, we then forward what we
+    # know to the bijector. This allows the `bijector` to have final say in the
+    # `event_shape`.
+    static_override = tensorshape_util.constant_value_as_shape(
+        self._override_event_shape)
+    return self.bijector.forward_event_shape(
+        static_override
+        if self._is_maybe_event_override
+        else self.distribution.event_shape)
+
+  def _batch_shape_tensor(self):
+    return distribution_util.pick_vector(
+        self._is_batch_override,
+        self._override_batch_shape,
+        self.distribution.batch_shape_tensor())
+
+  def _batch_shape(self):
+    # If there's a chance that the batch_shape has been overridden, we return
+    # what we statically know about the `batch_shape_override`. This works
+    # because: `_is_maybe_batch_override` means `static_override` is `None` or a
+    # non-empty list, i.e., we don't statically know the `batch_shape` or we do.
+    #
+    # Notice that this implementation parallels the `_event_shape` except that
+    # the `bijector` doesn't get to alter the `batch_shape`. Recall that
+    # `batch_shape` is a property of a distribution while `event_shape` is
+    # shared between both the `distribution` instance and the `bijector`.
+    static_override = tensorshape_util.constant_value_as_shape(
+        self._override_batch_shape)
+    return (static_override
+            if self._is_maybe_batch_override
+            else self.distribution.batch_shape)
+
+  def _sample_n(self, n, seed=None, **distribution_kwargs):
+    sample_shape = prefer_static.concat([
+        distribution_util.pick_vector(self._needs_rotation, self._empty, [n]),
+        self._override_batch_shape,
+        self._override_event_shape,
+        distribution_util.pick_vector(self._needs_rotation, [n], self._empty),
+    ], axis=0)
+    x = self.distribution.sample(sample_shape=sample_shape, seed=seed,
+                                 **distribution_kwargs)
+    x = self._maybe_rotate_dims(x)
+    # We'll apply the bijector in the `_call_sample_n` function.
+    return x
+
+  def _call_sample_n(self, sample_shape, seed, name, **kwargs):
+    # We override `_call_sample_n` rather than `_sample_n` so we can ensure that
+    # the result of `self.bijector.forward` is not modified (and thus caching
+    # works).
+    with self._name_scope(name):
+      sample_shape = tf.convert_to_tensor(
+          value=sample_shape, dtype=tf.int32, name="sample_shape")
+      sample_shape, n = self._expand_sample_shape_to_vector(
+          sample_shape, "sample_shape")
+
+      distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+      bijector_kwargs["condition"] = kwargs["condition"]
+      # First, generate samples. We will possibly generate extra samples in the
+      # event that we need to reinterpret the samples as part of the
+      # event_shape.
+      x = self._sample_n(n, seed, **distribution_kwargs)
+
+      # Next, we reshape `x` into its final form. We do this prior to the call
+      # to the bijector to ensure that the bijector caching works.
+      batch_event_shape = tf.shape(input=x)[1:]
+      final_shape = tf.concat([sample_shape, batch_event_shape], 0)
+      x = tf.reshape(x, final_shape)
+
+      # Finally, we apply the bijector's forward transformation. For caching to
+      # work, it is imperative that this is the last modification to the
+      # returned result.
+      # print(bijector_kwargs)
+      y = self.bijector.forward(x, **bijector_kwargs)
+      y = self._set_sample_static_shape(y, sample_shape)
+
+      return y
+
+  def _log_prob(self, y, **kwargs):
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    bijector_kwargs["condition"] = kwargs["condition"]
+    # For caching to work, it is imperative that the bijector is the first to
+    # modify the input.
+    x = self.bijector.inverse(y, **bijector_kwargs)
+    event_ndims = self._maybe_get_static_event_ndims()
+
+    ildj = self.bijector.inverse_log_det_jacobian(
+        y, event_ndims=event_ndims, **bijector_kwargs)
+    if self.bijector._is_injective:  # pylint: disable=protected-access
+      return self._finish_log_prob_for_one_fiber(
+          y, x, ildj, event_ndims, **distribution_kwargs)
+
+    lp_on_fibers = [
+        self._finish_log_prob_for_one_fiber(
+            y, x_i, ildj_i, event_ndims, **distribution_kwargs)
+        for x_i, ildj_i in zip(x, ildj)]
+    return tf.reduce_logsumexp(input_tensor=tf.stack(lp_on_fibers), axis=0)
+
+  def _finish_log_prob_for_one_fiber(self, y, x, ildj, event_ndims,
+                                     **distribution_kwargs):
+    """Finish computation of log_prob on one element of the inverse image."""
+    x = self._maybe_rotate_dims(x, rotate_right=True)
+    log_prob = self.distribution.log_prob(x, **distribution_kwargs)
+    if self._is_maybe_event_override:
+      log_prob = tf.reduce_sum(
+          input_tensor=log_prob, axis=self._reduce_event_indices)
+    log_prob += tf.cast(ildj, log_prob.dtype)
+    if self._is_maybe_event_override and isinstance(event_ndims, int):
+      tensorshape_util.set_shape(
+          log_prob,
+          tf.broadcast_static_shape(
+              tensorshape_util.with_rank_at_least(y.shape, 1)[:-event_ndims],
+              self.batch_shape))
+    return log_prob
+
+  def _prob(self, y, **kwargs):
+    if not hasattr(self.distribution, "_prob"):
+      return tf.exp(self.log_prob(y, **kwargs))
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+
+    x = self.bijector.inverse(y, **bijector_kwargs)
+    event_ndims = self._maybe_get_static_event_ndims()
+    ildj = self.bijector.inverse_log_det_jacobian(
+        y, event_ndims=event_ndims, **bijector_kwargs)
+    if self.bijector._is_injective:  # pylint: disable=protected-access
+      return self._finish_prob_for_one_fiber(
+          y, x, ildj, event_ndims, **distribution_kwargs)
+
+    prob_on_fibers = [
+        self._finish_prob_for_one_fiber(
+            y, x_i, ildj_i, event_ndims, **distribution_kwargs)
+        for x_i, ildj_i in zip(x, ildj)]
+    return sum(prob_on_fibers)
+
+  def _finish_prob_for_one_fiber(self, y, x, ildj, event_ndims,
+                                 **distribution_kwargs):
+    """Finish computation of prob on one element of the inverse image."""
+    x = self._maybe_rotate_dims(x, rotate_right=True)
+    prob = self.distribution.prob(x, **distribution_kwargs)
+    if self._is_maybe_event_override:
+      prob = tf.reduce_prod(input_tensor=prob, axis=self._reduce_event_indices)
+    prob *= tf.exp(tf.cast(ildj, prob.dtype))
+    if self._is_maybe_event_override and isinstance(event_ndims, int):
+      tensorshape_util.set_shape(
+          prob,
+          tf.broadcast_static_shape(
+              tensorshape_util.with_rank_at_least(y.shape, 1)[:-event_ndims],
+              self.batch_shape))
+    return prob
+
+  def _log_cdf(self, y, **kwargs):
+    if self._is_maybe_event_override:
+      raise NotImplementedError("log_cdf is not implemented when overriding "
+                                "event_shape")
+    if not self.bijector._is_injective:  # pylint: disable=protected-access
+      raise NotImplementedError("log_cdf is not implemented when "
+                                "bijector is not injective.")
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    x = self.bijector.inverse(y, **bijector_kwargs)
+    return self.distribution.log_cdf(x, **distribution_kwargs)
+
+  def _cdf(self, y, **kwargs):
+    if self._is_maybe_event_override:
+      raise NotImplementedError("cdf is not implemented when overriding "
+                                "event_shape")
+    if not self.bijector._is_injective:  # pylint: disable=protected-access
+      raise NotImplementedError("cdf is not implemented when "
+                                "bijector is not injective.")
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    x = self.bijector.inverse(y, **bijector_kwargs)
+    return self.distribution.cdf(x, **distribution_kwargs)
+
+  def _log_survival_function(self, y, **kwargs):
+    if self._is_maybe_event_override:
+      raise NotImplementedError("log_survival_function is not implemented when "
+                                "overriding event_shape")
+    if not self.bijector._is_injective:  # pylint: disable=protected-access
+      raise NotImplementedError("log_survival_function is not implemented when "
+                                "bijector is not injective.")
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    x = self.bijector.inverse(y, **bijector_kwargs)
+    return self.distribution.log_survival_function(x, **distribution_kwargs)
+
+  def _survival_function(self, y, **kwargs):
+    if self._is_maybe_event_override:
+      raise NotImplementedError("survival_function is not implemented when "
+                                "overriding event_shape")
+    if not self.bijector._is_injective:  # pylint: disable=protected-access
+      raise NotImplementedError("survival_function is not implemented when "
+                                "bijector is not injective.")
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    x = self.bijector.inverse(y, **bijector_kwargs)
+    return self.distribution.survival_function(x, **distribution_kwargs)
+
+  def _quantile(self, value, **kwargs):
+    if self._is_maybe_event_override:
+      raise NotImplementedError("quantile is not implemented when overriding "
+                                "event_shape")
+    if not self.bijector._is_injective:  # pylint: disable=protected-access
+      raise NotImplementedError("quantile is not implemented when "
+                                "bijector is not injective.")
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    # x_q is the "qth quantile" of X iff q = P[X <= x_q].  Now, since X =
+    # g^{-1}(Y), q = P[X <= x_q] = P[g^{-1}(Y) <= x_q] = P[Y <= g(x_q)],
+    # implies the qth quantile of Y is g(x_q).
+    inv_cdf = self.distribution.quantile(value, **distribution_kwargs)
+    return self.bijector.forward(inv_cdf, **bijector_kwargs)
+
+  def _mean(self, **kwargs):
+    if not self.bijector.is_constant_jacobian:
+      raise NotImplementedError("mean is not implemented for non-affine "
+                                "bijectors")
+
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    x = self.distribution.mean(**distribution_kwargs)
+
+    if self._is_maybe_batch_override or self._is_maybe_event_override:
+      # A batch (respectively event) shape override is only allowed if the batch
+      # (event) shape of the base distribution is [], so concatenating all the
+      # shapes does the right thing.
+      new_shape = prefer_static.concat([
+          prefer_static.ones_like(self._override_batch_shape),
+          self.distribution.batch_shape_tensor(),
+          prefer_static.ones_like(self._override_event_shape),
+          self.distribution.event_shape_tensor(),
+      ], 0)
+      x = tf.reshape(x, new_shape)
+      new_shape = prefer_static.concat(
+          [self.batch_shape_tensor(),
+           self.event_shape_tensor()], 0)
+      x = tf.broadcast_to(x, new_shape)
+
+    y = self.bijector.forward(x, **bijector_kwargs)
+
+    sample_shape = tf.convert_to_tensor(
+        value=[], dtype=tf.int32, name="sample_shape")
+    y = self._set_sample_static_shape(y, sample_shape)
+    return y
+
+  def _entropy(self, **kwargs):
+    if not self.bijector.is_constant_jacobian:
+      raise NotImplementedError("entropy is not implemented")
+    if not self.bijector._is_injective:  # pylint: disable=protected-access
+      raise NotImplementedError("entropy is not implemented when "
+                                "bijector is not injective.")
+    distribution_kwargs, bijector_kwargs = self._kwargs_split_fn(kwargs)
+    # Suppose Y = g(X) where g is a diffeomorphism and X is a continuous rv. It
+    # can be shown that:
+    #   H[Y] = H[X] + E_X[(log o abs o det o J o g)(X)].
+    # If is_constant_jacobian then:
+    #   E_X[(log o abs o det o J o g)(X)] = (log o abs o det o J o g)(c)
+    # where c can by anything.
+    entropy = self.distribution.entropy(**distribution_kwargs)
+    if self._is_maybe_event_override:
+      # H[X] = sum_i H[X_i] if X_i are mutually independent.
+      # This means that a reduce_sum is a simple rescaling.
+      entropy *= tf.cast(
+          tf.reduce_prod(input_tensor=self._override_event_shape),
+          dtype=dtype_util.base_dtype(entropy.dtype))
+    if self._is_maybe_batch_override:
+      new_shape = tf.concat([
+          prefer_static.ones_like(self._override_batch_shape),
+          self.distribution.batch_shape_tensor()
+      ], 0)
+      entropy = tf.reshape(entropy, new_shape)
+      multiples = tf.concat([
+          self._override_batch_shape,
+          prefer_static.ones_like(self.distribution.batch_shape_tensor())
+      ], 0)
+      entropy = tf.tile(entropy, multiples)
+    dummy = prefer_static.zeros(
+        shape=tf.concat(
+            [self.batch_shape_tensor(), self.event_shape_tensor()],
+            0),
+        dtype=self.dtype)
+    event_ndims = (
+        tensorshape_util.rank(self.event_shape)
+        if tensorshape_util.rank(self.event_shape) is not None else tf.size(
+            input=self.event_shape_tensor()))
+    ildj = self.bijector.inverse_log_det_jacobian(
+        dummy, event_ndims=event_ndims, **bijector_kwargs)
+
+    entropy -= tf.cast(ildj, entropy.dtype)
+    tensorshape_util.set_shape(entropy, self.batch_shape)
+    return entropy
+
+  def _maybe_validate_shape_override(self, override_shape, base_is_scalar,
+                                     validate_args, name):
+    """Helper to __init__ which ensures override batch/event_shape are valid."""
+    if override_shape is None:
+      override_shape = []
+
+    override_shape = tf.convert_to_tensor(
+        value=override_shape, dtype=tf.int32, name=name)
+
+    if not dtype_util.is_integer(override_shape.dtype):
+      raise TypeError("shape override must be an integer")
+
+    override_is_scalar = _is_scalar_from_shape_tensor(override_shape)
+    if tf.get_static_value(override_is_scalar):
+      return self._empty
+
+    dynamic_assertions = []
+
+    if tensorshape_util.rank(override_shape.shape) is not None:
+      if tensorshape_util.rank(override_shape.shape) != 1:
+        raise ValueError("shape override must be a vector")
+    elif validate_args:
+      dynamic_assertions += [
+          assert_util.assert_rank(
+              override_shape, 1, message="shape override must be a vector")
+      ]
+
+    if tf.get_static_value(override_shape) is not None:
+      if any(s < 0 for s in tf.get_static_value(override_shape)):
+        raise ValueError("shape override must have non-negative elements")
+    elif validate_args:
+      dynamic_assertions += [
+          assert_util.assert_non_negative(
+              override_shape,
+              message="shape override must have non-negative elements")
+      ]
+
+    is_both_nonscalar = prefer_static.logical_and(
+        prefer_static.logical_not(base_is_scalar),
+        prefer_static.logical_not(override_is_scalar))
+    if tf.get_static_value(is_both_nonscalar) is not None:
+      if tf.get_static_value(is_both_nonscalar):
+        raise ValueError("base distribution not scalar")
+    elif validate_args:
+      dynamic_assertions += [
+          assert_util.assert_equal(
+              is_both_nonscalar, False, message="base distribution not scalar")
+      ]
+
+    if not dynamic_assertions:
+      return override_shape
+    return distribution_util.with_dependencies(
+        dynamic_assertions, override_shape)
+
+  def _maybe_rotate_dims(self, x, rotate_right=False):
+    """Helper which rolls left event_dims left or right event_dims right."""
+    needs_rotation_const = tf.get_static_value(self._needs_rotation)
+    if needs_rotation_const is not None and not needs_rotation_const:
+      return x
+    ndims = prefer_static.rank(x)
+    n = (ndims - self._rotate_ndims) if rotate_right else self._rotate_ndims
+    perm = prefer_static.concat([
+        prefer_static.range(n, ndims), prefer_static.range(0, n)], axis=0)
+    return tf.transpose(a=x, perm=perm)
+
+  def _maybe_get_static_event_ndims(self):
+    if tensorshape_util.rank(self.event_shape) is not None:
+      return tensorshape_util.rank(self.event_shape)
+
+    event_ndims = tf.size(input=self.event_shape_tensor())
+    event_ndims_ = distribution_util.maybe_get_static_value(event_ndims)
+
+    if event_ndims_ is not None:
+      return event_ndims_
+
+    return event_ndims
+
+
+class ConditionalTransformedDistribution(TransformedDistribution):
+  """A TransformedDistribution that allows intrinsic conditioning."""
+
+  @deprecation.deprecated(
+      "2019-07-01",
+      "`ConditionalTransformedDistribution` is no longer required; "
+      "`TransformedDistribution` top-level functions now pass-through "
+      "`**kwargs`.",
+      warn_once=True)
+  def __new__(cls, *args, **kwargs):  # pylint: disable=unused-argument
+    return super(ConditionalTransformedDistribution, cls).__new__(cls)

--- a/scripts/HMC_high_SNR.py
+++ b/scripts/HMC_high_SNR.py
@@ -1,0 +1,303 @@
+from absl import app
+from absl import flags
+
+import os
+os.chdir('..')
+
+import tensorflow_hub as hub
+import tensorflow as tf
+import tensorflow_probability as tfp
+from tensorflow_probability import edward2 as ed
+import numpy as np
+tfd = tfp.distributions
+
+import galsim
+from galsim.bounds import _BoundsI
+import galflow
+
+import time
+from functools import partial
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+
+from gems.models import sersic2morph_model, dgm2morph_model, shear_fourier, convolve_fourier, dgm_model
+from gems.ed_utils import make_value_setter, make_log_joint_fn
+
+flags.DEFINE_integer("n", 100, "Number of iterations")
+flags.DEFINE_integer("N", 100, "Number of galaxies (try to use a square number for plots)")
+flags.DEFINE_float("noise_level", 0.001, "Noise level")
+flags.DEFINE_integer("n_chains", 1, "Number of chains in parallel")
+FLAGS = flags.FLAGS
+
+def gpsf2ikpsf(psf, interp_factor, padding_factor, stamp_size, im_scale):
+  Nk = stamp_size*interp_factor*padding_factor
+  bounds = _BoundsI(-Nk//2, Nk//2-1, -Nk//2, Nk//2-1)
+  imkpsf = psf.drawKImage(bounds=bounds,
+                    scale=2.*np.pi/(stamp_size*padding_factor* im_scale),
+                    recenter=False)
+  # imkpsf = tf.reshape(tf.convert_to_tensor(imkpsf.array, tf.complex64), [1, Nk, Nk])
+  imkpsf = imkpsf.array.reshape([1, Nk, Nk])
+  return imkpsf
+
+def main(_):
+  
+  # Prepare results storage
+  folder_name = 'hmc_high_SNR'
+  job_name = str(int(time.time()))
+  if not os.path.isdir('./res'):
+    os.mkdir('res')
+    os.mkdir('res/'+folder_name)
+  elif not os.path.isdir('./res/'+folder_name):
+    os.mkdir('res/'+folder_name)
+    
+  os.mkdir("res/"+folder_name+"/{}".format(job_name))
+  os.mkdir("res/"+folder_name+"/{}/params".format(job_name))
+  
+  NUM_GAL = FLAGS.N
+  N = int(np.sqrt(NUM_GAL))
+  
+  # Load auto encoder weights
+  encoder = hub.Module('../deep_galaxy_models/modules/vae_16/encoder')
+  decoder = hub.Module('../deep_galaxy_models/modules/vae_16/decoder')
+  
+  # Load COSMOS catalog
+  cat = galsim.COSMOSCatalog(dir='/gpfswork/rech/ykz/commun/galsim_catalogs/COSMOS_25.2_training_sample')
+
+
+  _log10 = tf.math.log(10.)
+  im_scale = 0.03 # COSMOS pixel size in arcsec
+  _pi = np.pi
+  stamp_size = 128
+  noise_level = FLAGS.noise_level
+
+  PIXEL_SCALE = 0.03
+  STAMP_SIZE = 128
+  interp_factor=2
+  padding_factor=1
+  Nk = STAMP_SIZE*interp_factor*padding_factor
+  bounds = _BoundsI(0, Nk//2, -Nk//2, Nk//2-1)    
+  
+  begin = time.time()
+
+  
+  # Generate observations
+  im_real_list = []
+  im_psf_list = []
+  psfs = []
+
+  mag_auto_list = []
+  z_phot_list = []
+  flux_radius_list = []
+
+  indices = []
+  degrees = galsim.AngleUnit(np.pi / 180.)
+  angle = galsim.Angle(90, unit=degrees)
+
+  ind = 0
+  while len(im_real_list) < NUM_GAL:
+    galp = cat.makeGalaxy(ind, gal_type='parametric')
+    if cat.param_cat['use_bulgefit'][cat.orig_index[ind]] == 0:
+      if galp.original.n < .4 or galp.original.half_light_radius > 3. or cat.param_cat['mag_auto'][cat.orig_index[ind]] < 22.5:
+        ind += 1
+      else:
+        galp = cat.makeGalaxy(ind, gal_type='parametric')
+        im_real = galsim.ImageF(STAMP_SIZE, STAMP_SIZE, scale=PIXEL_SCALE)
+        galr= cat.makeGalaxy(ind, gal_type='real', noise_pad_size=0.8*PIXEL_SCALE*STAMP_SIZE)
+        psf = galr.original_psf
+
+        if indices.count(ind)==1:
+          galr = galr.rotate(angle)
+          psf = psf.rotate(angle)
+
+        real = galsim.Convolve(psf, galr)
+        real.drawImage(im_real, method='no_pixel', use_true_center=False)
+
+        # PSF for the autocoder
+        imCp = psf.drawKImage(bounds=bounds,
+                                scale=2.*np.pi/(Nk * PIXEL_SCALE / interp_factor),
+                                recenter=False)
+        im_psf = np.abs(np.fft.fftshift(imCp.array, axes=0)).astype('float32')
+
+        # PSF for reconvolution
+        imkpsf = gpsf2ikpsf(psf=psf, interp_factor=1, padding_factor=1, stamp_size=STAMP_SIZE, im_scale=PIXEL_SCALE)
+        psfs.append(imkpsf)
+
+        im_real_list.append(im_real.array)
+        im_psf_list.append(im_psf)
+        indices.append(ind)
+
+        mag_auto_list.append(cat.param_cat['mag_auto'][cat.orig_index[ind]])
+        z_phot_list.append(cat.param_cat['zphot'][cat.orig_index[ind]])
+        flux_radius_list.append(cat.param_cat['flux_radius'][cat.orig_index[ind]])
+
+        print(ind, len(im_real_list))
+
+        if indices.count(ind)==2:
+          ind += 1
+    else:
+      ind += 1
+  
+  im_real_list = np.stack(im_real_list, axis=0)
+  im_psf_list = np.stack(im_psf_list, axis=0)
+
+  imkpsfs = tf.cast(tf.concat(psfs, axis=0), tf.complex64)
+
+  psf_in = tf.placeholder(shape=[NUM_GAL, 256, 129, 1], dtype=tf.float32)
+  im_in = tf.placeholder(shape=[NUM_GAL, 128, 128, 1], dtype=tf.float32)
+
+  code = encoder({'input':im_in, 'psf':psf_in})
+  reconstruction = decoder(code)
+
+  ims = tf.reshape(reconstruction, (1, NUM_GAL, STAMP_SIZE, STAMP_SIZE))
+
+  g1 = -0.03
+  g2 = +0.03
+  im_sheared = shear_fourier(ims, g1, g2)
+
+  ims = convolve_fourier(im_sheared, imkpsfs)
+
+  # obs = ims + tf.random.normal([1, NUM_GAL, stamp_size, stamp_size]) * noise_level
+  obs = ims + tf.random_normal([1, NUM_GAL, stamp_size, stamp_size]) * noise_level
+
+
+
+  sess = tf.Session()
+  sess.run(tf.global_variables_initializer())
+
+  y = sess.run(obs, feed_dict={psf_in:im_psf_list.reshape((NUM_GAL,256,129,1)), im_in:im_real_list.reshape((NUM_GAL,128,128,1))})
+  #np.save('/content/drive/MyDrive/GEMS/obs16AE.npy', y)
+
+  im_obs = y.reshape(N,N,STAMP_SIZE,STAMP_SIZE).transpose([0,2,1,3]).reshape([N*(STAMP_SIZE),N*(STAMP_SIZE)])
+  
+  k = 10
+  obs_cropped = y[:,:,k:-k, k:-k]
+  
+  batch_size = FLAGS.n_chains
+  obs_ = tf.repeat(obs_cropped, repeats=batch_size, axis=0)
+
+  log_prob = make_log_joint_fn(partial(dgm_model, 
+                                      batch_size=batch_size, 
+                                      sigma_e=noise_level, 
+                                      stamp_size=stamp_size,
+                                      num_gal=N*N, 
+                                      kpsf=imkpsfs, 
+                                      interp_factor = interp_factor,
+                                      padding_factor = padding_factor,
+                                      mag_auto_list=mag_auto_list, 
+                                      z_phot_list=z_phot_list, 
+                                      flux_radius_list=flux_radius_list,
+                                      fit_centroid=False))
+
+  s_gamma = .05
+  def target_log_prob_fn(prior_z, gamma):
+      return log_prob(
+          prior_z=prior_z,
+          gamma=gamma*s_gamma,
+          obs=obs_)
+    
+    
+  def target_log_prob_fn(prior_z, gamma#,
+                        #shift
+                        ):
+    return log_prob(
+        prior_z=prior_z,
+        gamma=gamma*s_gamma,
+        #shift=shift,
+        obs=obs_)
+
+  def loss_fn(lz, gamma#,
+              #shift
+              ):
+    return - target_log_prob_fn(lz, gamma#,
+                                #shift
+                               )
+  
+  # Chains intialization
+  lz = tf.Variable(tf.zeros([batch_size, NUM_GAL,16]), trainable=True, dtype=tf.float32)
+  gamma = tf.Variable(tf.zeros((batch_size, 2)), trainable=True, dtype=tf.float32)
+  
+  #lz = tf.Variable(tf.random.normal(shape=[batch_size, NUM_GAL,16]), trainable=True, dtype=tf.float32)
+  #gamma = tf.Variable(0.01 * tf.random.normal(shape=[batch_size,2]), trainable=True, dtype=tf.float32) * s_gamma
+  
+  #########
+  # Run HMC
+  #########
+
+  num_results = FLAGS.n
+  num_burnin_steps = 1
+
+  # Initialize the HMC transition kernel.
+  num_results =  FLAGS.n
+  num_burnin_steps = 200
+  
+  adaptive_hmc = tfp.mcmc.SimpleStepSizeAdaptation(
+    tfp.mcmc.HamiltonianMonteCarlo(
+      target_log_prob_fn=target_log_prob_fn,
+      num_leapfrog_steps=3,
+      step_size=.006),
+    num_adaptation_steps=int(num_burnin_steps * 0.8))
+
+  def get_samples():
+    samples, is_accepted = tfp.mcmc.sample_chain(
+        num_results=num_results,
+        num_burnin_steps=num_burnin_steps,
+        current_state=[
+                      lz,
+                      gamma/s_gamma,
+                      #shift,
+        ],
+        kernel=adaptive_hmc,
+        trace_fn=lambda _, pkr: pkr.inner_results.is_accepted)
+    return samples, is_accepted
+  
+  samples, is_accepted = get_samples()
+
+  lz_est = samples[0][:,:,:]
+  gamma_est = samples[1][:,:,:]*s_gamma
+  #shift_est = samples[2][:,0,:]
+  #gamma_true = true_gamma[0,:]
+
+  
+  start_sampling = time.time()
+
+  with tf.Session() as sess:
+    init = tf.global_variables_initializer()
+    sess.run(init)
+    lz_est, gamma_est, is_accepted = sess.run([lz_est, gamma_est, is_accepted]) 
+ 
+  end = time.time()
+  print('Total time: {:.2f}'.format((end - begin)/60.))
+  print('Sampling time: {:.2f}'.format((end - start_sampling)/60.))
+  print('')
+  print('accptance ratio:', is_accepted.sum()/len(is_accepted)/batch_size)
+  
+  
+  # Save results
+  np.save("res/"+folder_name+"/"+job_name+"/y.npy", y)
+  np.save("res/"+folder_name+"/"+job_name+"/samples_gamma_hmc.npy", gamma_est)
+  np.save("res/"+folder_name+"/"+job_name+"/samples_lz_hmc.npy", lz_est)
+  
+  # Shear chains
+  plt.figure()
+  plt.title('Shear (noise level: {}, num gals: {})'.format(noise_level, NUM_GAL))
+  plt.plot(gamma_est[:,:,0], alpha=0.5, color="tab:orange")
+  plt.plot(gamma_est[:,:,1], alpha=0.5, color="tab:blue")
+  
+  plt.axhline(g1, label='g1 ({})'.format(g1), color="tab:orange")
+  plt.axhline(g2, label='g2 ({})'.format(g2), color="tab:blue")
+  plt.legend()
+  plt.savefig("res/"+folder_name+"/"+job_name+"/shear.png")
+
+  # Latent z chains
+  plt.figure(figsize=[16, 7])
+  for k in range(6):
+    plt.title('latent_var ({})'.format(k))
+    plt.subplot(2,3,k+1)
+    for i in range(5):
+      plt.plot(lz_est[:,0,i,k], label='{}'.format(i))
+    plt.legend()
+  plt.savefig("res/"+folder_name+"/"+job_name+"/latent_z.png")
+  
+  
+if __name__ == "__main__":
+    app.run(main)


### PR DESCRIPTION
This PR contains copy pasted code from `tensorflow-probability` that I adapted to enable the following features:

- Training a RealNVP by block. Samples shape are `[batch_size, num_block, dim]`. A RealNVP is created for each block.
- Conditioning Flow's neural network by a 2-dimensional tensor with:

Here is an example of training 6 RealNVPs in parallel on 2-dimensional 2 moons:
![image](https://user-images.githubusercontent.com/30293694/220073822-f116632c-fd73-4b84-971d-4413b1c3648f.png)

Although the fit is not perfect due for Flow prior not necessarily centered, this can be used for NeuTra sampling:
![image](https://user-images.githubusercontent.com/30293694/220074121-d1d7bb96-7677-42dc-a338-05d61773418c.png)

```python
ess_hmc = tfp.mcmc.effective_sample_size(tf.reshape(samples_hmc, [-1, 2]))
print("ESS, HMC", sess.run(ess_hmc))
# ESS, HMC [600000.   410844.72]
ess_neutra = tfp.mcmc.effective_sample_size(tf.reshape(samples_neutra, [-1, 2]))
print("ESS, NeuTra", sess.run(ess_neutra))
# ESS, NeuTra [600000.   463283.94]
```

Colab does not support tensorflow 1 anymore so I uploaded the associated notebook on [Gist](https://gist.github.com/b-remy/651a20f278893d7262c6bb8c73632097).